### PR TITLE
Added stateless-component macro

### DIFF
--- a/example/src/de/otto/tesla/example/example_system.clj
+++ b/example/src/de/otto/tesla/example/example_system.clj
@@ -2,7 +2,8 @@
   (:require [de.otto.tesla.system :as system]
             [de.otto.tesla.example.calculating :as calculating]
             [de.otto.tesla.example.example-page :as example-page]
-            [com.stuartsierra.component :as c])
+            [com.stuartsierra.component :as c]
+            [de.otto.tesla.example.remote-services :as remote-services])
   (:gen-class))
 
 (defn example-calculation-function [input]
@@ -14,7 +15,8 @@
              (c/using (calculating/new-calculator example-calculation-function) [:metering :app-status]))
       (assoc :example-page
              (c/using (example-page/new-example-page) [:routes :calculator :app-status]))
-      (c/system-using {:server [:example-page]})))
+      (assoc :remote-calc (remote-services/new-remote-calc [:routes :calculator])) 
+      (c/system-using {:server [:remote-calc :example-page]})))
 
 (defn -main
   "starts up the production system."

--- a/example/src/de/otto/tesla/example/remote_services.clj
+++ b/example/src/de/otto/tesla/example/remote_services.clj
@@ -1,0 +1,18 @@
+(ns de.otto.tesla.example.remote-services
+  (:require [de.otto.tesla.util.stateless :as stateless]
+            [compojure.core :as compojure]
+            [de.otto.tesla.example.calculating :as calc]
+            [de.otto.tesla.stateful.routes :as rts]))
+
+(defn slurp-body [h]
+  (fn [req]
+    (h (update-in req [:body] slurp))))
+
+(stateless/stateless-component remote-calc
+                               [routes calculator]
+                               (rts/register-routes routes
+                                                    [(compojure/GET "/calculations" []
+                                                                    (str  (calc/calculations calculator)))
+                                                     (slurp-body
+                                                      (compojure/POST "/calculate" r
+                                                                      (calc/calculate! calculator (:body r))))]))

--- a/example/test/de/otto/tesla/example/remote_services_test.clj
+++ b/example/test/de/otto/tesla/example/remote_services_test.clj
@@ -1,0 +1,16 @@
+(ns de.otto.tesla.example.remote-services-test
+  (:require [clojure.test :refer :all]
+            [ring.mock.request :as mock]
+            [de.otto.tesla.util.test-utils :as u]
+            [de.otto.tesla.stateful.routes :as rts]
+            [de.otto.tesla.example.example-system :as example-system]))
+
+(deftest ^:unit remote-calc
+  (u/with-started [started (example-system/example-system {})]
+    (let [routes (rts/routes (:routes started))
+          res1 (routes (mock/body
+                        (mock/request :post "/calculate")
+                        "lowercaseword"))
+          res2 (routes (mock/request :get "/calculations"))]
+      (is (= res1 {:status 200 :body "LOWERCASEWORD" :headers {"Content-Type" "text/html; charset=utf-8"}}))
+      (is (= res2 {:status 200 :body "1" :headers {"Content-Type" "text/html; charset=utf-8"}})))))

--- a/src/de/otto/tesla/util/stateless.clj
+++ b/src/de/otto/tesla/util/stateless.clj
@@ -1,0 +1,25 @@
+(ns de.otto.tesla.util.stateless
+  (:require [com.stuartsierra.component]
+            [clojure.tools.logging]))
+
+(defmacro stateless-component
+  "Creates a component with no state of its own to manage, but that depends on other components to function"
+  [name dependencies & body]
+  `(do (defrecord ~name ~dependencies 
+         com.stuartsierra.component/Lifecycle
+         (~'start [self#]
+           (let [{:keys ~dependencies} self#]
+             (clojure.tools.logging/info ~(str "-> Starting " name))
+             ~@body
+             self#))
+         (~'stop [self#]
+           (let [{:keys ~dependencies} self#]
+             (clojure.tools.logging/info ~(str "<- stopping " name))
+             self#)))
+       (defn ~(symbol (str "new-" name))
+         ([]
+          (com.stuartsierra.component/using (~(symbol (str "map->" name)) {}) ~(mapv keyword dependencies)))
+         ([deps-map#]
+          (com.stuartsierra.component/using (~(symbol (str "map->" name)) {}) deps-map#)))))
+
+


### PR DESCRIPTION
The new-{name} function can now also optionally take a dependency map. 

Feel free to close this pull request without merging if the preference is to not provide the stateless-component at this time. 
