### PR TITLE
Made complete status aggregation strategy configurable

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject de.otto/tesla-microservice "0.1.4"
+(defproject de.otto/tesla-microservice "0.1.5"
             :description "basic microservice."
             :url "https://github.com/otto-de/tesla-microservice"
             :license { :name "Apache License 2.0" 

--- a/test/de/otto/tesla/stateful/app_status_test.clj
+++ b/test/de/otto/tesla/stateful/app_status_test.clj
@@ -11,7 +11,8 @@
             [de.otto.tesla.util.test-utils :as u]
             [de.otto.tesla.system :as system]
             [de.otto.tesla.stateful.routes :as rts]
-            [ring.mock.request :as mock]))
+            [ring.mock.request :as mock]
+            [de.otto.status :as s]))
 
 (defn- serverless-system [runtime-config]
   (dissoc
@@ -123,3 +124,16 @@
                           status-map (json/read-json (:body (handlers response)))]
                       (is (= (get-in status-map [:application :version]) "test.version"))
                       (is (= (get-in status-map [:application :git]) "test.githash"))))))
+
+(deftest determine-status-strategy
+  (testing "it should use strict stategy if none is configured"
+    (let [config {:status-aggregation nil}]
+      (is (= (app-status/aggregation-strategy config) s/strict-strategy))))
+
+  (testing "it should use forgiving stategy if forgiving is configured"
+    (let [config {:status-aggregation "forgiving"}]
+      (is (= (app-status/aggregation-strategy config) s/forgiving-strategy))))
+
+  (testing "it should use strict stategy if something else is configured"
+    (let [config {:status-aggregation "unknown"}]
+      (is (= (app-status/aggregation-strategy config) s/strict-strategy)))))


### PR DESCRIPTION
We made the complete status aggregation strategy configurable as our service's status should only be error if all sub-status are error, not if just one sub-status is error. The aggregation strategy can be configured via properties using "status-aggregation" as key with values "strict" or "forgiving".
