### PR TITLE
Small refactoring in serving component

### DIFF
--- a/src/de/otto/tesla/stateful/serving.clj
+++ b/src/de/otto/tesla/stateful/serving.clj
@@ -7,11 +7,11 @@
 ;; The serving component is the frontend of the system.
 ;; It accepts requests and returns the data to be used by consuming systems.
 ;; For the moment a simple, blocking implementation with an embedded jetty is chosen.
-(defrecord Server [config calculator]
+(defrecord Server [config]
   component/Lifecycle
   (start [self]
     (log/info "-> starting server")
-    (let [port (Integer. (get-in self [:config :config :server-port]))
+    (let [port (Integer. (get-in config [:config :server-port]))
           all-routes (rts/routes (:routes self))
           server (jetty/run-jetty all-routes {:port port :join? false})]
       (.setGracefulShutdown server 100)


### PR DESCRIPTION
Hi,

as I was browsing through the code I was confused that the serving component declared a field 'calculator'. I guess it does not belong there.

While I was at it, I reduced on level of nested keys by using the declared field 'config'.
