### PR TITLE
Cleanup (project.clj)

### DIFF
--- a/dev-resources/logback.xml
+++ b/dev-resources/logback.xml
@@ -1,13 +1,10 @@
 <configuration>
     <contextName>tesla</contextName>
 
-    <conversionRule conversionWord="mescaped"
-                    converterClass="de.otto.tesla.util.escapingmessageconverter" />
-
     <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
         <append>true</append>
         <encoder>
-            <pattern>%d{ISO8601} %-5p logger=%c thread=%t msg="%mescaped"%n</pattern>
+            <pattern>%d{ISO8601} %-5p logger=%c thread=%t msg="%m"%n</pattern>
         </encoder>
     </appender>
 
@@ -26,7 +23,7 @@
         </triggeringPolicy>
 
         <encoder>
-            <pattern>%d{ISO8601} %-5p logger=%c thread=%t  msg="%mescaped"%n</pattern>
+            <pattern>%d{ISO8601} %-5p logger=%c thread=%t  msg="%m"%n</pattern>
         </encoder>
     </appender>
 

--- a/project.clj
+++ b/project.clj
@@ -18,7 +18,6 @@
                            ;; io
                            [ring "1.3.2"]
                            [compojure "1.3.4"]
-                           [hiccup "1.0.5"]
                            [metrics-clojure "2.5.1"]
                            [metrics-clojure-graphite "2.5.1"]
 
@@ -28,8 +27,7 @@
                            [ch.qos.logback/logback-core "1.1.3"]
                            [ch.qos.logback/logback-classic "1.1.3"]
 
-                           ;; testing
-                           [ring-mock "0.1.5"]]
+                           ]
 
             :exclusions [org.clojure/clojure
                          org.slf4j/slf4j-nop
@@ -37,11 +35,7 @@
                          log4j
                          commons-logging/commons-logging]
 
-            :plugins [[lein-environ "1.0.0"]]
             :aot [de.otto.tesla.util.escapingmessageconverter]
-            :clean-targets [:target-path :compile-path "target"]
-            :source-paths ["src"]
-            :java-source-paths ["src/java"]
             :test-selectors {:default     (constantly true)
                              :integration :integration
                              :unit        :unit
@@ -49,7 +43,15 @@
             :profiles {:test    {:aot [de.otto.tesla.util.escapingmessageconverter]
                                  :env {:metering-reporter "console"
                                        :server-port       "9991"
-                                       :cache-dir         "/tmp"}}
+                                       :cache-dir         "/tmp"}
+                                 :dependencies [[ring-mock "0.1.5"]]
+                                 }
                        :meta    {:env {:app-name :tesla-meta}}
-                       :uberjar {:aot :all}}
+                       :uberjar {:aot :all}
+                       :dev {:dependencies [[javax.servlet/servlet-api "2.5"]]
+                             :plugins [[lein-ancient "0.5.4"]
+                                       [lein-marginalia "0.8.0"]
+                                       [lein-environ "1.0.0"]]
+
+                             }}
             :test-paths ["test" "test-resources"])

--- a/project.clj
+++ b/project.clj
@@ -23,9 +23,6 @@
 
                            ;; logging
                            [org.clojure/tools.logging "0.3.1"]
-                           [org.slf4j/slf4j-api "1.7.12"]
-                           [ch.qos.logback/logback-core "1.1.3"]
-                           [ch.qos.logback/logback-classic "1.1.3"]
 
                            ]
 
@@ -35,20 +32,20 @@
                          log4j
                          commons-logging/commons-logging]
 
-            :aot [de.otto.tesla.util.escapingmessageconverter]
             :test-selectors {:default     (constantly true)
                              :integration :integration
                              :unit        :unit
                              :all         (constantly true)}
-            :profiles {:test    {:aot [de.otto.tesla.util.escapingmessageconverter]
-                                 :env {:metering-reporter "console"
+            :profiles {:test    {:env {:metering-reporter "console"
                                        :server-port       "9991"
                                        :cache-dir         "/tmp"}
-                                 :dependencies [[ring-mock "0.1.5"]]
-                                 }
+                                 :dependencies [[ring-mock "0.1.5"]]}
                        :meta    {:env {:app-name :tesla-meta}}
                        :uberjar {:aot :all}
-                       :dev {:dependencies [[javax.servlet/servlet-api "2.5"]]
+                       :dev {:dependencies [[javax.servlet/servlet-api "2.5"]
+                                            [org.slf4j/slf4j-api "1.7.12"]
+                                            [ch.qos.logback/logback-core "1.1.3"]
+                                            [ch.qos.logback/logback-classic "1.1.3"]]
                              :plugins [[lein-ancient "0.5.4"]
                                        [lein-marginalia "0.8.0"]
                                        [lein-environ "1.0.0"]]

--- a/src/de/otto/tesla/stateful/keep_alive.clj
+++ b/src/de/otto/tesla/stateful/keep_alive.clj
@@ -1,13 +1,18 @@
 (ns de.otto.tesla.stateful.keep-alive
-  "This component is responsible for keeping the system alive."
+  "This component is responsible for keeping the system alive by creating a non-deamonized noop thread."
   (:require [clojure.tools.logging :as log]
             [com.stuartsierra.component :as component]))
 
-(defn do-nothing []
-  (while true (Thread/sleep 60000)))
+(defn do-nothing [running?]
+  (while @running?
+    (try
+      (Thread/sleep 60000)
+      (catch InterruptedException i
+        (log/debug "keepalive thread sleep interrupted!"))
+      (catch Exception e (throw e)))))
 
-(defn keep-alive []
-  (let [thread (Thread. do-nothing)]
+(defn keep-alive [running?]
+  (let [thread (Thread. (partial do-nothing running?) "keepalive")]
     (.start thread)
     thread))
 
@@ -15,11 +20,21 @@
   component/Lifecycle
   (start [self]
     (log/info "-> starting keepalive thread.")
-    (assoc self :thread (keep-alive)))
+    (let [running? (atom true)]
+      (assoc self
+        :running? running?
+        :thread (keep-alive running?))))
 
   (stop [self]
     (log/info "<- stopping keepalive thread.")
-    (.stop (:thread self))
+    (try
+      (when-let [running? (:running? self)]
+        (reset! running? false)
+        (.interrupt (:thread self)))                        ;; try the "not-so-unfriendly"-method first.
+      (Thread/sleep 1000)
+      (.stop (:thread self))                                ;; and finally kill it.
+      (catch Exception e
+        (log/debug e "Error stopping keepalive thread.")))
     self))
 
 (defn new-keep-alive [] (map->KeepAlive {}))

--- a/src/de/otto/tesla/util/escapingmessageconverter.clj
+++ b/src/de/otto/tesla/util/escapingmessageconverter.clj
@@ -1,7 +1,0 @@
-(ns de.otto.tesla.util.escapingmessageconverter
-  (:import ch.qos.logback.classic.pattern.ClassicConverter)
-  (:gen-class
-    :extends ch.qos.logback.classic.pattern.ClassicConverter))
-
-(defn -convert [this event]
-  (clojure.string/replace (.getFormattedMessage event) "\"" "'"))

--- a/test-resources/logback-test.xml
+++ b/test-resources/logback-test.xml
@@ -3,13 +3,11 @@
     <contextName>tesla</contextName>
 
 
-    <conversionRule conversionWord="mescaped"
-                    converterClass="de.otto.tesla.util.escapingmessageconverter" />
 
     <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
         <append>true</append>
         <encoder>
-            <pattern>%d{HH:mm:ss,SSS} %-5p %c{5} %t "%mescaped"%n</pattern>
+            <pattern>%d{HH:mm:ss,SSS} %-5p %c{5} %t "%m"%n</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
Basic cleanup:
- moved dependencies and plugins to profiles to clean dependency graph in systems dependant on tesla
- removed logback specific code.

You need to apply the following patch to otto-de/tesla-examples (aka add the slf4j-ap + logback dependencies):

```
From 9e84389d690f19b03ba7e7a3fc9bd8c67a4a3c5f Mon Sep 17 00:00:00 2001
From: Christian Betz <christian.betz@performance-media.de>
Date: Mon, 1 Jun 2015 12:36:37 +0200
Subject: [PATCH] cleaned up logging in tesla, so add it here

---
 simple-example/project.clj | 7 +++++--
 1 file changed, 5 insertions(+), 2 deletions(-)

diff --git a/simple-example/project.clj b/simple-example/project.clj
index 5e56015..ff14da6 100644
--- a/simple-example/project.clj
+++ b/simple-example/project.clj
@@ -1,10 +1,13 @@
 (defproject de.otto/tesla-simple-example "0.1.0"
             :description "a simple example of an application build with tesla-microservice."
             :url "https://github.com/otto-de/tesla-examples"
            :license { :name "Apache License 2.0" 
                        :url "http://www.apache.org/license/LICENSE-2.0.html"}
             :scm { :name "git"
               :url "https://github.com/otto-de/tesla-microservice"}
             :dependencies [[org.clojure/clojure "1.6.0"]
-                           [de.otto/tesla-microservice "0.1.12"]]
+                           [de.otto/tesla-microservice "0.1.12"]
+                           [org.slf4j/slf4j-api "1.7.12"]
+                           [ch.qos.logback/logback-core "1.1.3"]
+                           [ch.qos.logback/logback-classic "1.1.3"]]
             :main ^:skip-aot de.otto.tesla.example.example-system)
-- 
2.2.1


```
