### PR TITLE
those strange "double" route definitions were necessary to keep middl…

### DIFF
--- a/src/de/otto/tesla/stateful/app_status.clj
+++ b/src/de/otto/tesla/stateful/app_status.clj
@@ -82,14 +82,16 @@
 (defn make-handler
   [self]
   (let [status-path (get-in self [:config :config :status-url] "/status")]
-    (c/routes (-> (c/GET status-path
+    (c/routes (c/GET status-path
+                     []
+                (-> (c/GET status-path
                          []
                     (status-response self))
                   (ring-defaults/wrap-defaults
                     (assoc ring-defaults/site-defaults :session false
                                                        :cookies false
                                                        :static false
-                                                       :proxy true))))))
+                                                       :proxy true)))))))
 
 
 (defrecord ApplicationStatus [config handler metering]

--- a/src/de/otto/tesla/stateful/health.clj
+++ b/src/de/otto/tesla/stateful/health.clj
@@ -22,14 +22,16 @@
 (defn make-handler
   [self]
   (let [health-path (get-in self [:config :config :health-url] "/health")]
-    (c/routes (-> (c/GET health-path
+    (c/routes (c/GET health-path
+                     []
+                (-> (c/GET health-path
                          []
                     (health-response self))
                   (ring-defaults/wrap-defaults
                     (assoc ring-defaults/site-defaults :session false
                                                        :cookies false
                                                        :static false
-                                                       :proxy true))))))
+                                                       :proxy true)))))))
 
 (defn lock-application [self]
   (reset! (:locked self) true))


### PR DESCRIPTION
…eware to the routes specified. I.e., go down the middleware route only if we know the middleware should really be applied to the route.

Otherwise, the middleware will be checked before the route will signal it's not matching. In my case, anti-forgery-middleware will return an error for POST calls to an API.
