### PR TITLE
edn-/property configuration symmetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The scheduler executes functions based on a schedule. It is based on [overtones 
 
 To use the scheduler, you have to hook the `scheduler component` into your system. 
 ```clj
-(assoc your-system :scheduler (c/using (sch/new-scheduler) []))
+(assoc your-system :scheduler (c/using (sch/new-scheduler) [:config]))
 ```
 
 `your-system` is the result from the function `base-system` from `de.otto.tesla.system`.
@@ -48,6 +48,7 @@ To actually use it you have to pass the `:scheduler` to the component in which i
 ```
 
 where the `scheduled-function` is executed every `interval` in milliseconds. 
+The number of threads of the overtone-pool used, can be specified by the property `scheduler-cpu-count`.
 
 ### app-status
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ your configuration:
 }
 ```
 
+ENV-variables are read with [environ](https://github.com/weavejester/environ). To see
+which keyword represents which ENV-var have a look in their docs. 
+
 ## Addons
 
 The basis included is stripped to the very minimum. Additional functionality is available as addons:

--- a/README.md
+++ b/README.md
@@ -49,6 +49,26 @@ To actually use it you have to pass the `:scheduler` to the component in which i
 
 where the `scheduled-function` is executed every `interval` in milliseconds. 
 
+### app-status
+
+The app-status indicates the current status of your microservice. To use it you can register a status function to it.
+
+Here is a simple example for a function that checks if an atom is empty or not.
+
+```clj
+(de.otto.tesla.stateful.app-status/register-status-fun app-status #(status atom))
+``` 
+
+The `app-status` is injected under the keyword :app-status from the base system.
+
+```clj
+(defn status [atom]
+      (let [status (if @atom :error :ok)
+            message (if @atom "Atom is empty" "Atom is not empty")]
+           (de.otto.status/status-detail :status-id status message)))
+```
+
+For further information and usages take a look at the: [status library](https://github.com/otto-de/status)
 
 ## Choosing a server
 

--- a/README.md
+++ b/README.md
@@ -18,11 +18,37 @@ _tesla-microservice_ is used for a number of different services now. Still it is
 
 * Load configuration from filesystem.
 * Aggregate a status.
+* Execute functions with a scheduler
 * Reply to a health check.
 * Deliver a json status report.
 * Report to graphite using the metrics library.
 * Manage handlers using ring.
 * Shutdown gracefully. If necessary delayed, so load-balancers have time to notice.
+
+## Examples
+
+* A growing set of example apllications can be found at [tesla-examples](https://github.com/otto-de/tesla-examples).
+* David & Germán created an example application based, among other, on tesla-microservice. They wrote a very instructive [blog post about it](http://blog.agilityfeat.com/2015/03/clojure-walking-skeleton/)
+* Moritz created [tesla-pubsub-service](https://bitbucket.org/DerGuteMoritz/tesla-pubsub-service). It showcases how to connect components via core.async channels. Also the embedded jetty was replaced by immutant.
+
+### Scheduler
+
+The scheduler executes functions based on a schedule. It is based on [overtones at-at](https://github.com/overtone/at-at) project.
+
+To use the scheduler, you have to hook the `scheduler component` into your system. 
+```clj
+(assoc your-system :scheduler (c/using (sch/new-scheduler) []))
+```
+
+`your-system` is the result from the function `base-system` from `de.otto.tesla.system`.
+
+To actually use it you have to pass the `:scheduler` to the component in which it is invoked like this:
+```clj
+(de.otto.tesla.stateful.scheduler/schedule scheduler scheduled-function interval)
+```
+
+where the `scheduled-function` is executed every `interval` in milliseconds. 
+
 
 ## Choosing a server
 
@@ -70,13 +96,6 @@ The basis included is stripped to the very minimum. Additional functionality is 
 * [tesla-cachefile](https://github.com/otto-de/tesla-cachefile): Read and write a cachefile. Locally or in hdfs.
 
 More features will be released at a later time as separate addons.
-
-
-## Examples
-
-* A growing set of example apllications can be found at [tesla-examples](https://github.com/otto-de/tesla-examples).
-* David & Germán created an example application based, among other, on tesla-microservice. They wrote a very instructive [blog post about it](http://blog.agilityfeat.com/2015/03/clojure-walking-skeleton/)
-* Moritz created [tesla-pubsub-service](https://bitbucket.org/DerGuteMoritz/tesla-pubsub-service). It showcases how to connect components via core.async channels. Also the embedded jetty was replaced by immutant.
 
 ## FAQ
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject de.otto/tesla-microservice "0.4.0"
+(defproject de.otto/tesla-microservice "0.4.1-SNAPSHOT"
   :description "basic microservice."
   :url "https://github.com/otto-de/tesla-microservice"
   :license {:name "Apache License 2.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject de.otto/tesla-microservice "0.3.37-SNAPSHOT"
+(defproject de.otto/tesla-microservice "0.3.37"
   :description "basic microservice."
   :url "https://github.com/otto-de/tesla-microservice"
   :license {:name "Apache License 2.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject de.otto/tesla-microservice "0.3.34"
+(defproject de.otto/tesla-microservice "0.3.35"
   :description "basic microservice."
   :url "https://github.com/otto-de/tesla-microservice"
   :license {:name "Apache License 2.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject de.otto/tesla-microservice "0.3.33"
+(defproject de.otto/tesla-microservice "0.3.34"
   :description "basic microservice."
   :url "https://github.com/otto-de/tesla-microservice"
   :license {:name "Apache License 2.0"

--- a/project.clj
+++ b/project.clj
@@ -1,10 +1,10 @@
-(defproject de.otto/tesla-microservice "0.4.1-SNAPSHOT"
+(defproject org.clojars.deas/tesla-microservice "0.4.1-SNAPSHOT"
   :description "basic microservice."
-  :url "https://github.com/otto-de/tesla-microservice"
+  :url "https://github.com/deas/tesla-microservice"
   :license {:name "Apache License 2.0"
             :url  "http://www.apache.org/license/LICENSE-2.0.html"}
   :scm {:name "git"
-        :url  "https://github.com/otto-de/tesla-microservice"}
+        :url  "https://github.com/deas/tesla-microservice"}
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/data.json "0.2.6"]
                  [org.clojure/tools.logging "0.3.1"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject de.otto/tesla-microservice "0.4.0-SNAPSHOT"
+(defproject de.otto/tesla-microservice "0.4.0"
   :description "basic microservice."
   :url "https://github.com/otto-de/tesla-microservice"
   :license {:name "Apache License 2.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject de.otto/tesla-microservice "0.3.38-SNAPSHOT"
+(defproject de.otto/tesla-microservice "0.4.0-SNAPSHOT"
   :description "basic microservice."
   :url "https://github.com/otto-de/tesla-microservice"
   :license {:name "Apache License 2.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject de.otto/tesla-microservice "0.3.37"
+(defproject de.otto/tesla-microservice "0.3.38-SNAPSHOT"
   :description "basic microservice."
   :url "https://github.com/otto-de/tesla-microservice"
   :license {:name "Apache License 2.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject de.otto/tesla-microservice "0.3.35"
+(defproject de.otto/tesla-microservice "0.3.36"
   :description "basic microservice."
   :url "https://github.com/otto-de/tesla-microservice"
   :license {:name "Apache License 2.0"

--- a/project.clj
+++ b/project.clj
@@ -16,7 +16,7 @@
                  [clojurewerkz/propertied "1.2.0"]
                  [com.stuartsierra/component "0.3.1"]
                  [compojure "1.5.1"]
-                 [environ "1.0.3"]
+                 [environ "1.1.0"]
                  [metrics-clojure "2.7.0"]
                  [metrics-clojure-graphite "2.7.0"]
                  [overtone/at-at "1.2.0"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject de.otto/tesla-microservice "0.3.36"
+(defproject de.otto/tesla-microservice "0.3.37-SNAPSHOT"
   :description "basic microservice."
   :url "https://github.com/otto-de/tesla-microservice"
   :license {:name "Apache License 2.0"
@@ -27,6 +27,7 @@
                org.slf4j/slf4j-log4j12
                log4j
                commons-logging/commons-logging]
+  :lein-release {:deploy-via :clojars}
 
   :test-selectors {:default     (constantly true)
                    :integration :integration
@@ -38,5 +39,5 @@
                                       [ch.qos.logback/logback-core "1.1.7"]
                                       [ch.qos.logback/logback-classic "1.1.7"]
                                       [ring-mock "0.1.5"]]
-                       :plugins      [[lein-ancient "0.6.10"]]}}
+                       :plugins      [[lein-ancient "0.6.10"][lein-release/lein-release "1.0.9"]]}}
   :test-paths ["test" "test-resources"])

--- a/src/de/otto/tesla/stateful/keep_alive.clj
+++ b/src/de/otto/tesla/stateful/keep_alive.clj
@@ -5,7 +5,7 @@
   (:import (java.util.concurrent CountDownLatch)))
 
 (defn exit-keep-alive []
-  (log/info "<- stopping keepalive"))
+  (log/info "<- stopping keepalive thread: " (.getName (Thread/currentThread))))
 
 (defn enter-keep-alive []
   (log/info "-> starting keepalive thread: " (.getName (Thread/currentThread))))
@@ -22,13 +22,11 @@
 (defrecord KeepAlive [cd-latch]
   component/Lifecycle
   (start [self]
-    (log/info "-> starting keepalive")
     (let [cd-latch (CountDownLatch. 1)]
       (start-keep-alive-thread cd-latch)
       (assoc self :cd-latch cd-latch)))
 
   (stop [self]
-    (log/info "<- stopping keepalive")
     (.countDown cd-latch)
     self))
 

--- a/src/de/otto/tesla/stateful/scheduler.clj
+++ b/src/de/otto/tesla/stateful/scheduler.clj
@@ -3,21 +3,16 @@
             [clojure.tools.logging :as log]
             [overtone.at-at :as at]))
 
-
-(defn schedule
-  "Calls function repeatedly every ms-period milliseconds."
-
-  ([self function# ms-period]
-   (schedule self function# ms-period false))
-  ([{executor :executor} function# ms-period interspaced?]
-   "Calls function repeatedly every ms-period milliseconds if interspaced? is false.
-    Else calls function every ms-period milliseconds after the function returned."
-   (if interspaced?
-     (at/interspaced ms-period function# executor)
-     (at/every ms-period function# executor))))
-
 (defn as-seq [v]
   (apply concat v))
+
+(defn schedule
+  "Calls function repeatedly every ms-period milliseconds if interspaced? is false.
+    Else calls function every ms-period milliseconds after the function returned."
+  [{:keys [executor]} function# ms-period & {:as args}]
+  (if (:interspaced? args)
+    (apply (partial at/interspaced ms-period function# executor) (as-seq args))
+    (apply (partial at/every ms-period function# executor) (as-seq args))))
 
 (defn new-pool [config]
   (let [scheduler-config (get-in config [:config :scheduler] {})]

--- a/src/de/otto/tesla/stateful/scheduler.clj
+++ b/src/de/otto/tesla/stateful/scheduler.clj
@@ -47,15 +47,12 @@
   (start [self]
     (log/info "-> Start Scheduler")
     (let [new-self (assoc self
-                     :schedules (atom [])
                      :executor (new-pool config))]
       (app-status/register-status-fun app-status (partial scheduler-app-status new-self))
       new-self))
 
   (stop [self]
     (log/info "<- Stop Scheduler")
-    (doseq [job @(:schedules self)]
-      (at/kill job))
     (at/stop-and-reset-pool! (:executor self))
     self))
 

--- a/src/de/otto/tesla/stateful/scheduler.clj
+++ b/src/de/otto/tesla/stateful/scheduler.clj
@@ -1,7 +1,9 @@
 (ns de.otto.tesla.stateful.scheduler
   (:require [com.stuartsierra.component :as c]
             [clojure.tools.logging :as log]
-            [overtone.at-at :as at]))
+            [overtone.at-at :as at]
+            [de.otto.tesla.stateful.app-status :as app-status])
+  (:import (java.util.concurrent ScheduledThreadPoolExecutor)))
 
 (defn as-seq [v]
   (apply concat v))
@@ -18,13 +20,36 @@
   (let [scheduler-config (get-in config [:config :scheduler] {})]
     (apply at/mk-pool (-> scheduler-config (as-seq)))))
 
-(defrecord Scheduler [config]
+(defn as-readable-time [l]
+  (.format (java.text.SimpleDateFormat. "EEEE HH':'mm':'ss's'") l))
+
+(defn job-details [{:keys [id created-at initial-delay desc ms-period scheduled?]}]
+  [(keyword (str id)) {:desc         desc
+                       :createdAt    (as-readable-time created-at)
+                       :initialDelay initial-delay
+                       :msPeriod     ms-period
+                       :scheduled?   @scheduled?}])
+
+(defn pool-details [{:keys [pool-atom]}]
+  (when pool-atom
+    (let [{:keys [^ScheduledThreadPoolExecutor thread-pool]} @pool-atom]
+      {:threadPool {:active    (.getActiveCount thread-pool)
+                    :queueSize (.size (.getQueue thread-pool))
+                    :poolSize  (.getPoolSize thread-pool)}})))
+
+(defn scheduler-app-status [{:keys [executor]}]
+  {:scheduler {:status        :ok
+               :poolInfo      (pool-details executor)
+               :scheduledJobs (into {} (map job-details (at/scheduled-jobs executor)))}})
+
+(defrecord Scheduler [config app-status]
   c/Lifecycle
   (start [self]
     (log/info "-> Start Scheduler")
     (let [new-self (assoc self
                      :schedules (atom [])
                      :executor (new-pool config))]
+      (app-status/register-status-fun app-status (partial scheduler-app-status new-self))
       new-self))
 
   (stop [self]

--- a/src/de/otto/tesla/stateful/scheduler.clj
+++ b/src/de/otto/tesla/stateful/scheduler.clj
@@ -16,15 +16,12 @@
      (at/interspaced ms-period function# executor)
      (at/every ms-period function# executor))))
 
-(defn only-specified [config]
-  (filter (fn [[_ v]] (not (nil? v))) config))
-
 (defn as-seq [v]
   (apply concat v))
 
 (defn new-pool [config]
-  (let [config {:cpu-count (get-in config [:config :scheduler-num-threads])}]
-    (apply at/mk-pool (-> (only-specified config) (as-seq)))))
+  (let [scheduler-config (get-in config [:config :scheduler] {})]
+    (apply at/mk-pool (-> scheduler-config (as-seq)))))
 
 (defrecord Scheduler [config]
   c/Lifecycle

--- a/src/de/otto/tesla/util/sanitize.clj
+++ b/src/de/otto/tesla/util/sanitize.clj
@@ -1,6 +1,6 @@
 (ns de.otto.tesla.util.sanitize)
 
-(def checklist ["password" "pw" "passwd"])
+(def checklist ["password" "pw" "passwd" "private"])
 
 (defn hide-passwd [k v]
   (if (some true? (map #(.contains (name k) %) checklist))

--- a/src/de/otto/tesla/util/sanitize.clj
+++ b/src/de/otto/tesla/util/sanitize.clj
@@ -1,6 +1,6 @@
 (ns de.otto.tesla.util.sanitize)
 
-(def checklist ["password" "pw" "passwd" "private"])
+(def checklist ["password" "pw" "passwd" "private" "secret"])
 
 (defn hide-passwd [k v]
   (if (some true? (map #(.contains (name k) %) checklist))

--- a/src/de/otto/tesla/util/sanitize.clj
+++ b/src/de/otto/tesla/util/sanitize.clj
@@ -1,6 +1,6 @@
 (ns de.otto.tesla.util.sanitize)
 
-(def checklist ["password" "pwd" "passwd"])
+(def checklist ["password" "pw" "passwd"])
 
 (defn hide-passwd [k v]
   (if (some true? (map #(.contains (name k) %) checklist))

--- a/test/de/otto/tesla/stateful/configuring_test.clj
+++ b/test/de/otto/tesla/stateful/configuring_test.clj
@@ -36,7 +36,7 @@
                     (is (= (get-in edn-conf [:foo :edn]) "baz")))))
 
 (deftest ^:unit should-read-property-from-custom-edn-file
-  (with-redefs [env/env {:config-file "test.edn"}]
+  (with-redefs [env/env {:config-file "./test-resources/test.edn"}]
     (u/with-started [started (test-system {})]
                     (let [edn-conf (get-in started [:conf :config])]
                       (is (= (get-in edn-conf [:health-url]) "/test/health"))

--- a/test/de/otto/tesla/stateful/keep_alive_test.clj
+++ b/test/de/otto/tesla/stateful/keep_alive_test.clj
@@ -1,0 +1,21 @@
+(ns de.otto.tesla.stateful.keep-alive-test
+  (:require
+    [clojure.test :refer :all]
+    [de.otto.tesla.stateful.keep-alive :as kalive]
+    [com.stuartsierra.component :as c]))
+
+(deftest starting-and-stopping-the-keepalive-component
+  (testing "should not start and stop keepalive-thread"
+    (let [entered? (atom false)
+          exited? (atom false)]
+      (with-redefs [kalive/enter-keep-alive (fn [] (reset! entered? true))
+                    kalive/exit-keep-alive (fn [] (reset! exited? true))]
+        (is (= false @entered?))
+        (is (= false @exited?))
+        (let [started (-> (kalive/new-keep-alive)
+                          (c/start))]
+          (is (= true @entered?))
+          (is (= false @exited?))
+          (c/stop started))
+        (is (= true @entered?))
+        (is (= true @exited?))))))

--- a/test/de/otto/tesla/stateful/scheduler_test.clj
+++ b/test/de/otto/tesla/stateful/scheduler_test.clj
@@ -2,13 +2,14 @@
   (:require [clojure.test :refer :all]
             [de.otto.tesla.system :as system]
             [de.otto.tesla.stateful.scheduler :as schedule]
-            [de.otto.tesla.util.test-utils :as u]))
+            [de.otto.tesla.util.test-utils :as u]
+            [overtone.at-at :as at]
+            [com.stuartsierra.component :as c]))
 
 (defn- serverless-system [runtime-config]
-  (->(dissoc
-    (system/base-system runtime-config)
-    :server)
-     (assoc :scheduler (schedule/new-scheduler))))
+  (-> (system/base-system runtime-config)
+      (dissoc :server)
+      (assoc :scheduler (c/using (schedule/new-scheduler) [:config]))))
 
 (deftest ^:unit should-call-function-at-scheduled-rate
   (u/with-started [system (serverless-system {:host-name "bar" :server-port "0123"})]
@@ -21,6 +22,31 @@
 
                     (testing "Function gets called every 10 ms AFTER the function last returned"
                       (let [calls (atom 0)]
-                        (schedule/schedule scheduler #((Thread/sleep 10)(swap! calls inc)) 10 true)
+                        (schedule/schedule scheduler #((Thread/sleep 10) (swap! calls inc)) 10 true)
                         (Thread/sleep 25)
                         (is (= @calls 1)))))))
+
+(defn assert-map-args! [args-assert-val]
+  (fn [& {:as args}] (is (= args args-assert-val))))
+
+(deftest ^:unit configuring-the-schedule
+  (testing "should filter out nil values"
+    (is (= [[:b :bar] [:c :foo]]
+           (schedule/only-specified {:a nil
+                                     :b :bar
+                                     :c :foo}))))
+
+  (testing "should pass nr cpus to pool if specified"
+    (let [config {:scheduler-num-threads 2
+                  :some-other :property}]
+      (with-redefs [at/stop-and-reset-pool! (constantly nil)
+                    at/mk-pool (assert-map-args! {:cpu-count 2})]
+        (u/with-started [system (serverless-system config)]
+                        (is ())))))
+
+  (testing "should pass nothing to pool if nothing is specified"
+    (let [config {:some-other :property}]
+      (with-redefs [at/stop-and-reset-pool! (constantly nil)
+                    at/mk-pool (assert-map-args! nil)]
+        (u/with-started [system (serverless-system config)]
+                        (is ()))))))

--- a/test/de/otto/tesla/stateful/scheduler_test.clj
+++ b/test/de/otto/tesla/stateful/scheduler_test.clj
@@ -20,9 +20,15 @@
                         (Thread/sleep 25)
                         (is (= @calls 3))))
 
+                    (testing "Function gets called every 10 ms with initial delay"
+                      (let [calls (atom 0)]
+                        (schedule/schedule scheduler #(swap! calls inc) 10 :initial-delay 10)
+                        (Thread/sleep 25)
+                        (is (= @calls 2))))
+
                     (testing "Function gets called every 10 ms AFTER the function last returned"
                       (let [calls (atom 0)]
-                        (schedule/schedule scheduler #((Thread/sleep 10) (swap! calls inc)) 10 true)
+                        (schedule/schedule scheduler #((Thread/sleep 10) (swap! calls inc)) 10 :interspaced? true)
                         (Thread/sleep 25)
                         (is (= @calls 1)))))))
 

--- a/test/de/otto/tesla/stateful/scheduler_test.clj
+++ b/test/de/otto/tesla/stateful/scheduler_test.clj
@@ -19,19 +19,19 @@
                   (let [scheduler (:scheduler system)]
                     (testing "Function gets called every 10 ms"
                       (let [calls (atom 0)]
-                        (schedule/schedule scheduler #(swap! calls inc) 10)
+                        (at/every 10 #(swap! calls inc) (schedule/pool scheduler))
                         (Thread/sleep 25)
                         (is (= @calls 3))))
 
                     (testing "Function gets called every 10 ms with initial delay"
                       (let [calls (atom 0)]
-                        (schedule/schedule scheduler #(swap! calls inc) 10 :initial-delay 10)
+                        (at/every 10 #(swap! calls inc) (schedule/pool scheduler) :initial-delay 10)
                         (Thread/sleep 25)
                         (is (= @calls 2))))
 
                     (testing "Function gets called every 10 ms AFTER the function last returned"
                       (let [calls (atom 0)]
-                        (schedule/schedule scheduler #((Thread/sleep 10) (swap! calls inc)) 10 :interspaced? true)
+                        (at/interspaced 10 #((Thread/sleep 10) (swap! calls inc)) (schedule/pool scheduler))
                         (Thread/sleep 25)
                         (is (= @calls 1)))))))
 
@@ -63,8 +63,8 @@
                     (let [{:keys [scheduler handler]} system
                           handler-fn (handler/handler handler)]
                       (testing "should register and return status-details in app-status"
-                        (schedule/schedule scheduler #(Thread/sleep 10) 10 :desc "Job 1")
-                        (schedule/schedule scheduler #(Thread/sleep 10) 10 :interspaced? true :desc "Job 2")
+                        (at/every 10 #(Thread/sleep 10) (schedule/pool scheduler) :desc "Job 1")
+                        (at/interspaced 10 #(Thread/sleep 10) (schedule/pool scheduler) :desc "Job 2")
                         (is (= {:poolInfo      {:threadPool {:active    2
                                                              :poolSize  2
                                                              :queueSize 0}}

--- a/test/de/otto/tesla/stateful/scheduler_test.clj
+++ b/test/de/otto/tesla/stateful/scheduler_test.clj
@@ -30,17 +30,14 @@
   (fn [& {:as args}] (is (= args args-assert-val))))
 
 (deftest ^:unit configuring-the-schedule
-  (testing "should filter out nil values"
-    (is (= [[:b :bar] [:c :foo]]
-           (schedule/only-specified {:a nil
-                                     :b :bar
-                                     :c :foo}))))
-
   (testing "should pass nr cpus to pool if specified"
-    (let [config {:scheduler-num-threads 2
-                  :some-other :property}]
+    (let [config {:scheduler {:cpu-count      2
+                              :stop-delayed?  false
+                              :stop-periodic? true}}]
       (with-redefs [at/stop-and-reset-pool! (constantly nil)
-                    at/mk-pool (assert-map-args! {:cpu-count 2})]
+                    at/mk-pool (assert-map-args! {:cpu-count      2
+                                                  :stop-delayed?  false
+                                                  :stop-periodic? true})]
         (u/with-started [system (serverless-system config)]
                         (is ())))))
 

--- a/test/de/otto/tesla/util/sanitize_test.clj
+++ b/test/de/otto/tesla/util/sanitize_test.clj
@@ -5,10 +5,10 @@
 (deftest ^:unit should-sanitize-passwords
   (is (= (san/hide-passwds {:somerandomstuff                    "not-so-secret"
                         :somerandomstuff-passwd-somerandomstuff "secret"
-                        :somerandomstuff-pwd-somerandomstuff    "longersecret"
+                        :somerandomstuff-pw-somerandomstuff    "longersecret"
                         :nested                                 {:some-passwd "secret"}})
          {:somerandomstuff                        "not-so-secret"
           :somerandomstuff-passwd-somerandomstuff "***"
-          :somerandomstuff-pwd-somerandomstuff    "***"
+          :somerandomstuff-pw-somerandomstuff    "***"
           :nested                                 {:some-passwd "***"}
           })))

--- a/test/de/otto/tesla/util/sanitize_test.clj
+++ b/test/de/otto/tesla/util/sanitize_test.clj
@@ -3,12 +3,14 @@
             [de.otto.tesla.util.sanitize :as san]))
 
 (deftest ^:unit should-sanitize-passwords
-  (is (= (san/hide-passwds {:somerandomstuff                    "not-so-secret"
-                        :somerandomstuff-passwd-somerandomstuff "secret"
-                        :somerandomstuff-pw-somerandomstuff    "longersecret"
-                        :nested                                 {:some-passwd "secret"}})
+  (is (= (san/hide-passwds {:somerandomstuff                        "not-so-secret"
+                            :somerandomstuff-passwd-somerandomstuff "secret"
+                            :somerandomstuff-pw-somerandomstuff     "longersecret"
+                            :my-private-stuff                       "sonotpublic"
+                            :nested                                 {:some-passwd "secret"}})
          {:somerandomstuff                        "not-so-secret"
           :somerandomstuff-passwd-somerandomstuff "***"
-          :somerandomstuff-pw-somerandomstuff    "***"
+          :somerandomstuff-pw-somerandomstuff     "***"
+          :my-private-stuff                       "***"
           :nested                                 {:some-passwd "***"}
           })))

--- a/test/de/otto/tesla/util/sanitize_test.clj
+++ b/test/de/otto/tesla/util/sanitize_test.clj
@@ -7,10 +7,12 @@
                             :somerandomstuff-passwd-somerandomstuff "secret"
                             :somerandomstuff-pw-somerandomstuff     "longersecret"
                             :my-private-stuff                       "sonotpublic"
+                            :my-secret-stuff                        "psstsecret"
                             :nested                                 {:some-passwd "secret"}})
          {:somerandomstuff                        "not-so-secret"
           :somerandomstuff-passwd-somerandomstuff "***"
           :somerandomstuff-pw-somerandomstuff     "***"
           :my-private-stuff                       "***"
+          :my-secret-stuff                        "***"
           :nested                                 {:some-passwd "***"}
           })))


### PR DESCRIPTION
I expected edn-/property configuration meant to be symmetrical. This was not the case so far. In fact, it was not possible to load edn from a file. My expectations could be wrong. This PR makes it as symmetrical as I expected things. Other than that, I decided `:resource` may be a bit clearer than `:properties`, so I changed it along the way as well.
