### PR TITLE
Add 'secret' to status page sanitizer

### DIFF
--- a/src/de/otto/tesla/util/sanitize.clj
+++ b/src/de/otto/tesla/util/sanitize.clj
@@ -1,6 +1,6 @@
 (ns de.otto.tesla.util.sanitize)
 
-(def checklist ["password" "pw" "passwd" "private"])
+(def checklist ["password" "pw" "passwd" "private" "secret"])
 
 (defn hide-passwd [k v]
   (if (some true? (map #(.contains (name k) %) checklist))

--- a/test/de/otto/tesla/util/sanitize_test.clj
+++ b/test/de/otto/tesla/util/sanitize_test.clj
@@ -7,10 +7,12 @@
                             :somerandomstuff-passwd-somerandomstuff "secret"
                             :somerandomstuff-pw-somerandomstuff     "longersecret"
                             :my-private-stuff                       "sonotpublic"
+                            :my-secret-stuff                        "psstsecret"
                             :nested                                 {:some-passwd "secret"}})
          {:somerandomstuff                        "not-so-secret"
           :somerandomstuff-passwd-somerandomstuff "***"
           :somerandomstuff-pw-somerandomstuff     "***"
           :my-private-stuff                       "***"
+          :my-secret-stuff                        "***"
           :nested                                 {:some-passwd "***"}
           })))


### PR DESCRIPTION
Hi,
we think that properties which contain "secret" in their name should also be sanitized on the status page.

Or you should consider making this configurable.
