### PR TITLE
Handler with timings

### DIFF
--- a/src/de/otto/tesla/stateful/handler.clj
+++ b/src/de/otto/tesla/stateful/handler.clj
@@ -73,6 +73,12 @@
   (register-timed-handler [self handler] [self handler uri-resource-chooser-fn use-status-codes?])
   (handler [self]))
 
+
+(def all-resources identity)
+(def all-but-last-resource #(if (empty? %) % (pop %)))
+(def use-status-codes true)
+(def do-not-use-status-codes false)
+
 (defrecord Handler [config]
   component/Lifecycle
   (start [self]
@@ -94,7 +100,7 @@
                                                  :handler      handler})))
 
   (register-timed-handler [self handler]
-    (register-timed-handler self handler identity true))
+    (register-timed-handler self handler all-resources true))
 
   (register-timed-handler [self handler uri-resource-chooser-fn use-status-codes?]
     (swap! (:registered-handlers self) #(conj % {:timed?                  true

--- a/src/de/otto/tesla/stateful/handler.clj
+++ b/src/de/otto/tesla/stateful/handler.clj
@@ -46,11 +46,11 @@
       (string/split splittable #"/")
       [])))
 
-(defn request-based-timer-id [reporting-base-path {:keys [use-status-codes?] :as item} request response]
+(defn request-based-timer-id [reporting-base-path item request response]
   (concat
     reporting-base-path
     (extract-uri-resources item request)
-    (when use-status-codes? [(str (:status response))])))
+    [(str (:status response))]))
 
 (defn- report-request-timings! [{:keys [reporting-base-path] :as self} item request response time-taken]
   (let [timer-id (request-based-timer-id reporting-base-path item request response)]
@@ -70,14 +70,12 @@
 
 (defprotocol HandlerContainer
   (register-handler [self handler])
-  (register-timed-handler [self handler] [self handler uri-resource-chooser-fn use-status-codes?])
+  (register-timed-handler [self handler] [self handler uri-resource-chooser-fn])
   (handler [self]))
 
 
 (def all-resources identity)
 (def all-but-last-resource butlast)
-(def use-status-codes true)
-(def do-not-use-status-codes false)
 
 (defrecord Handler [config]
   component/Lifecycle
@@ -100,13 +98,12 @@
                                                  :handler      handler})))
 
   (register-timed-handler [self handler]
-    (register-timed-handler self handler all-resources true))
+    (register-timed-handler self handler all-resources))
 
-  (register-timed-handler [self handler uri-resource-chooser-fn use-status-codes?]
+  (register-timed-handler [self handler uri-resource-chooser-fn]
     (swap! (:registered-handlers self) #(conj % {:timed?                  true
                                                  :handler-name            (new-handler-name self)
                                                  :uri-resource-chooser-fn uri-resource-chooser-fn
-                                                 :use-status-codes?       use-status-codes?
                                                  :handler                 handler})))
 
   (handler [self]

--- a/src/de/otto/tesla/stateful/handler.clj
+++ b/src/de/otto/tesla/stateful/handler.clj
@@ -4,8 +4,11 @@
             [compojure.core :as c]))
 
 (defprotocol HandlerContainer
-  (register-handler [self routes])
+  (register-handler [self handler] [self handler-name handler])
   (handler [self]))
+
+(defn new-handler-name [self]
+  (str "tesla-handler-" (count @(:the-handlers self))))
 
 (defrecord Handler []
   component/Lifecycle
@@ -16,10 +19,15 @@
     (log/info "<- stopping Handler")
     self)
   HandlerContainer
-  (register-handler [self handler] (swap! (:the-handlers self) #(conj % handler)))
+  (register-handler [self handler]
+    (register-handler self (new-handler-name self) handler))
+
+  (register-handler [self handler-name handler]
+    (swap! (:the-handlers self) #(conj % [handler-name handler])))
+
   (handler [self]
     (let [handlers (:the-handlers self)]
-      (apply c/routes @handlers))))
+      (apply c/routes (map second @handlers)))))
 
 (defn new-handler []
   (map->Handler {}))

--- a/src/de/otto/tesla/stateful/handler.clj
+++ b/src/de/otto/tesla/stateful/handler.clj
@@ -10,10 +10,10 @@
 (defn- sliding-window-timer [reporting-time-window-in-min]
   (Timer. (SlidingTimeWindowReservoir. reporting-time-window-in-min TimeUnit/MINUTES)))
 
-(defn register-timer [timer mname]
+(defn- register-timer [timer mname]
   (.register ^MetricRegistry mcore/default-registry mname timer))
 
-(defn new-stored-and-registered-timer [timers reporting-time-window-in-min mname]
+(defn- new-stored-and-registered-timer [timers reporting-time-window-in-min mname]
   (let [t (sliding-window-timer reporting-time-window-in-min)]
     (register-timer t mname)
     (swap! timers assoc mname t)
@@ -36,7 +36,7 @@
 
 (def without-leading-and-trailing-slash #"/?(.*[^/])/?")
 
-(defn trimmed-uri-path [uri]
+(defn- trimmed-uri-path [uri]
   (let [path (.getPath (URI. uri))]
     (second (re-matches without-leading-and-trailing-slash path))))
 
@@ -46,7 +46,7 @@
       (string/split splittable #"/")
       [])))
 
-(defn request-based-timer-id [reporting-base-path item request response]
+(defn- request-based-timer-id [reporting-base-path item request response]
   (concat
     reporting-base-path
     (extract-uri-resources item request)

--- a/src/de/otto/tesla/stateful/handler.clj
+++ b/src/de/otto/tesla/stateful/handler.clj
@@ -23,11 +23,12 @@
     (register-handler self (new-handler-name self) handler))
 
   (register-handler [self handler-name handler]
-    (swap! (:the-handlers self) #(conj % [handler-name handler])))
+    (swap! (:the-handlers self) #(conj % {:handler-name handler-name
+                                          :handler      handler})))
 
   (handler [self]
     (let [handlers (:the-handlers self)]
-      (apply c/routes (map second @handlers)))))
+      (apply c/routes (map :handler @handlers)))))
 
 (defn new-handler []
   (map->Handler {}))

--- a/src/de/otto/tesla/stateful/handler.clj
+++ b/src/de/otto/tesla/stateful/handler.clj
@@ -1,13 +1,14 @@
 (ns de.otto.tesla.stateful.handler
   (:require [com.stuartsierra.component :as component]
             [clojure.tools.logging :as log]
-            [compojure.core :as c]))
+            [metrics.timers :as timers])
+  (:import (java.util.concurrent TimeUnit)))
 
 (defprotocol HandlerContainer
   (register-handler [self handler] [self handler-name handler])
   (handler [self]))
 
-(defn new-handler-name [self]
+(defn- new-handler-name [self]
   (str "tesla-handler-" (count @(:the-handlers self))))
 
 (defn- handler-execution-result [request {:keys [handler-name handler]}]
@@ -15,14 +16,39 @@
     {:response     response
      :handler-name handler-name}))
 
-(defrecord Handler []
+(defn- first-handler-result [handlers request]
+  (some (partial handler-execution-result request) handlers))
+
+(defn- default-handler [handlers]
+  (fn [request]
+    (-> (first-handler-result handlers request) :response)))
+
+(defn- report-request-timings! [handler-name time-taken]
+  (-> (timers/timer ["handler" "requests" handler-name])
+      (.update time-taken TimeUnit/MILLISECONDS)))
+
+(defn- time-taken [start-time]
+  (- (System/currentTimeMillis) start-time))
+
+(defn- timed-handler [handlers]
+  (fn [request]
+    (let [start-time (System/currentTimeMillis)]
+      (when-let [{:keys [response handler-name]} (first-handler-result handlers request)]
+        (report-request-timings! handler-name (time-taken start-time))
+        response))))
+
+(defrecord Handler [config]
   component/Lifecycle
   (start [self]
     (log/info "-> starting Handler")
-    (assoc self :the-handlers (atom [])))
+    (assoc self
+      :report-timings? (get-in config [:config :handler :report-timings?])
+      :the-handlers (atom [])))
+
   (stop [self]
     (log/info "<- stopping Handler")
     self)
+
   HandlerContainer
   (register-handler [self handler]
     (register-handler self (new-handler-name self) handler))
@@ -32,10 +58,10 @@
                                           :handler      handler})))
 
   (handler [self]
-    (let [handlers (:the-handlers self)]
-      (fn [request]
-        (-> (some (partial handler-execution-result request) @handlers)
-            :response)))))
+    (let [handlers @(:the-handlers self)]
+      (if (:report-timings? self)
+        (timed-handler handlers)
+        (default-handler handlers)))))
 
 (defn new-handler []
   (map->Handler {}))

--- a/src/de/otto/tesla/stateful/handler.clj
+++ b/src/de/otto/tesla/stateful/handler.clj
@@ -10,6 +10,11 @@
 (defn new-handler-name [self]
   (str "tesla-handler-" (count @(:the-handlers self))))
 
+(defn- handler-execution-result [request {:keys [handler-name handler]}]
+  (when-let [response (handler request)]
+    {:response     response
+     :handler-name handler-name}))
+
 (defrecord Handler []
   component/Lifecycle
   (start [self]
@@ -28,7 +33,9 @@
 
   (handler [self]
     (let [handlers (:the-handlers self)]
-      (apply c/routes (map :handler @handlers)))))
+      (fn [request]
+        (-> (some (partial handler-execution-result request) @handlers)
+            :response)))))
 
 (defn new-handler []
   (map->Handler {}))

--- a/src/de/otto/tesla/stateful/handler.clj
+++ b/src/de/otto/tesla/stateful/handler.clj
@@ -11,10 +11,9 @@
 (defn- new-handler-name [self]
   (str "tesla-handler-" (count @(:the-handlers self))))
 
-(defn- handler-execution-result [request {:keys [handler-name handler]}]
-  (when-let [response (handler request)]
-    {:response     response
-     :handler-name handler-name}))
+(defn- handler-execution-result [request {handler-fn :handler :as handler-map}]
+  (when-let [response (handler-fn request)]
+    (assoc handler-map :response response)))
 
 (defn- first-handler-result [handlers request]
   (some (partial handler-execution-result request) handlers))

--- a/src/de/otto/tesla/stateful/handler.clj
+++ b/src/de/otto/tesla/stateful/handler.clj
@@ -75,7 +75,7 @@
 
 
 (def all-resources identity)
-(def all-but-last-resource #(if (empty? %) % (pop %)))
+(def all-but-last-resource butlast)
 (def use-status-codes true)
 (def do-not-use-status-codes false)
 

--- a/src/de/otto/tesla/system.clj
+++ b/src/de/otto/tesla/system.clj
@@ -35,8 +35,8 @@
 (defn base-system [runtime-config]
   (c/system-map
     :keep-alive (keep-alive/new-keep-alive)
-    :handler (handler/new-handler)
     :config (c/using (configuring/new-config runtime-config) [:keep-alive])
+    :handler (c/using (handler/new-handler) [:config])
     :metering (c/using (metering/new-metering) [:config])
     :health (c/using (health/new-health) [:config :handler])
     :app-status (c/using (app-status/new-app-status) [:config :handler :metering])

--- a/test/de/otto/tesla/stateful/handler_test.clj
+++ b/test/de/otto/tesla/stateful/handler_test.clj
@@ -49,7 +49,7 @@
 
   (testing "should build path with all but last resource of uri"
     (let [item {:timed?                  true
-                :uri-resource-chooser-fn #(if (empty? %) % (pop %))
+                :uri-resource-chooser-fn butlast
                 :use-status-codes?       false}]
       (is (= ["base" "path" "foo" "bar" "baz"]
              (handler/request-based-timer-id ["base" "path"] item {:uri "/foo/bar/baz/baf?item=123"} {})))

--- a/test/de/otto/tesla/stateful/handler_test.clj
+++ b/test/de/otto/tesla/stateful/handler_test.clj
@@ -28,48 +28,51 @@
           (is (= :ping ((handler/handler handler) :pong)))
           (is (= [["tesla-handler-0" 100] ["tesla-handler-1" 100]] @reportings)))))))
 
+(def request-based-timer-id #'handler/request-based-timer-id)
+
 (deftest building-timer-id
   (testing "should build path with first resource of uri"
     (let [item {:timed?                  true
                 :uri-resource-chooser-fn (partial take 1)}]
       (is (= ["base" "path" "foo" "200"]
-             (handler/request-based-timer-id ["base" "path"] item {:uri "/foo/bar/baz/baf?item=123"} {:status 200})))
+             (request-based-timer-id ["base" "path"] item {:uri "/foo/bar/baz/baf?item=123"} {:status 200})))
       (is (= ["base" "path" "200"]
-             (handler/request-based-timer-id ["base" "path"] item {:uri "/?item=123"} {:status 200})))))
+             (request-based-timer-id ["base" "path"] item {:uri "/?item=123"} {:status 200})))))
 
   (testing "should build path with first 2 resources of uri"
     (let [item {:timed?                  true
                 :uri-resource-chooser-fn (partial take 2)}]
       (is (= ["base" "path" "foo" "bar" "200"]
-             (handler/request-based-timer-id ["base" "path"] item {:uri "/foo/bar/baz/baf?item=123"} {:status 200})))
+             (request-based-timer-id ["base" "path"] item {:uri "/foo/bar/baz/baf?item=123"} {:status 200})))
       (is (= ["base" "path" "200"]
-             (handler/request-based-timer-id ["base" "path"] item {:uri "/?item=123"} {:status 200})))))
+             (request-based-timer-id ["base" "path"] item {:uri "/?item=123"} {:status 200})))))
 
   (testing "should build path with all but last resource of uri"
     (let [item {:timed?                  true
                 :uri-resource-chooser-fn butlast}]
       (is (= ["base" "path" "foo" "bar" "baz" "200"]
-             (handler/request-based-timer-id ["base" "path"] item {:uri "/foo/bar/baz/baf?item=123"} {:status 200})))
+             (request-based-timer-id ["base" "path"] item {:uri "/foo/bar/baz/baf?item=123"} {:status 200})))
       (is (= ["base" "path" "foo" "bar" "baz" "baf" "bif" "200"]
-             (handler/request-based-timer-id ["base" "path"] item {:uri "/foo/bar/baz/baf/bif/bum?item=123"} {:status 200})))
+             (request-based-timer-id ["base" "path"] item {:uri "/foo/bar/baz/baf/bif/bum?item=123"} {:status 200})))
       (is (= ["base" "path" "200"]
-             (handler/request-based-timer-id ["base" "path"] item {:uri "/?item=123"} {:status 200}))))))
+             (request-based-timer-id ["base" "path"] item {:uri "/?item=123"} {:status 200}))))))
 
 (deftest request-based-timer-id-with-status
   (testing "should build path with status code"
     (let [item {:timed?                  true
                 :uri-resource-chooser-fn (partial take 2)}]
       (is (= ["base" "path" "foo" "bar" "200"]
-             (handler/request-based-timer-id ["base" "path"] item {:uri "/foo/bar/baz/baf?item=123"} {:status 200})))
+             (request-based-timer-id ["base" "path"] item {:uri "/foo/bar/baz/baf?item=123"} {:status 200})))
       (is (= ["base" "path" "foo" "bar" "404"]
-             (handler/request-based-timer-id ["base" "path"] item {:uri "/foo/bar/baz/baf?item=123"} {:status 404})))
+             (request-based-timer-id ["base" "path"] item {:uri "/foo/bar/baz/baf?item=123"} {:status 404})))
       (is (= ["base" "path" "foo" "bar" "500"]
-             (handler/request-based-timer-id ["base" "path"] item {:uri "/foo/bar/baz/baf?item=123"} {:status 500}))))))
+             (request-based-timer-id ["base" "path"] item {:uri "/foo/bar/baz/baf?item=123"} {:status 500}))))))
 
-(deftest trimmed-uri-path
+(def trimmed-uri-path #'handler/trimmed-uri-path)
+(deftest trimmed-uri-path-test
   (testing "should trim uri path"
-    (is (= "foo/bar/baz" (handler/trimmed-uri-path "/foo/bar/baz?a=b&c=d")))
-    (is (= nil (handler/trimmed-uri-path "/?a=b&c=d")))))
+    (is (= "foo/bar/baz" (trimmed-uri-path "/foo/bar/baz?a=b&c=d")))
+    (is (= nil (trimmed-uri-path "/?a=b&c=d")))))
 
 (deftest reporting-base-path
   (testing "should use default reporting base-path"

--- a/test/de/otto/tesla/stateful/handler_test.clj
+++ b/test/de/otto/tesla/stateful/handler_test.clj
@@ -8,15 +8,7 @@
     (let [handler (-> (handler/new-handler) (c/start))]
       (handler/register-handler handler (fn [r] (when (= r :ping) :pong)))
       (handler/register-handler handler (fn [r] (when (= r :pong) :ping)))
-      (is (= ["tesla-handler-0" "tesla-handler-1"] (map :handler-name @(:the-handlers handler))))
-      (is (= :pong ((handler/handler handler) :ping)))
-      (is (= :ping ((handler/handler handler) :pong)))))
-
-  (testing "should register a handler with a name and return a single handling-function"
-    (let [handler (-> (handler/new-handler) (c/start))]
-      (handler/register-handler handler "ping" (fn [r] (when (= r :ping) :pong)))
-      (handler/register-handler handler "pong" (fn [r] (when (= r :pong) :ping)))
-      (is (= ["ping" "pong"] (map :handler-name @(:the-handlers handler))))
+      (is (= ["tesla-handler-0" "tesla-handler-1"] (map :handler-name @(:registered-handlers handler))))
       (is (= :pong ((handler/handler handler) :ping)))
       (is (= :ping ((handler/handler handler) :pong))))))
 
@@ -24,40 +16,69 @@
   (testing "should use timed handler"
     (let [reportings (atom [])]
       (with-redefs [handler/time-taken (constantly 100)
-                    handler/report-request-timings! (fn [_ handler-name time-taken] (swap! reportings conj [handler-name time-taken]))]
-        (let [handler (-> (handler/->Handler {:config {:handler {:report-timings? true}}}) (c/start))]
-          (handler/register-handler handler (fn [r] (when (= r :ping) :pong)))
-          (handler/register-handler handler (fn [r] (when (= r :pong) :ping)))
-          (is (= ["tesla-handler-0" "tesla-handler-1"] (map :handler-name @(:the-handlers handler))))
+                    handler/report-request-timings! (fn [_ item _ _ time-taken] (swap! reportings conj [(:handler-name item) time-taken]))]
+        (let [handler (-> (handler/new-handler) (c/start))]
+          (handler/register-timed-handler handler (fn [r] (when (= r :ping) :pong)))
+          (handler/register-timed-handler handler (fn [r] (when (= r :pong) :ping)))
+          (is (= ["tesla-handler-0" "tesla-handler-1"]
+                 (map :handler-name @(:registered-handlers handler))))
           (is (= :pong ((handler/handler handler) :ping)))
           (is (= [["tesla-handler-0" 100]] @reportings))
           (is (= :ping ((handler/handler handler) :pong)))
           (is (= [["tesla-handler-0" 100] ["tesla-handler-1" 100]] @reportings)))))))
 
-(def timer-id handler/timer-id)
 (deftest building-timer-id
-  (testing "should build timer-id"
-    (is (= ["a" "b" "c" "d"]
-           (timer-id ["a" "b" "c"] "d")))
-    (is (= ["d"]
-           (timer-id [] "d")))))
+  (testing "should build path with first resource of uri"
+    (let [item {:timed?                  true
+                :uri-resource-chooser-fn (partial take 1)
+                :use-status-codes?       false}]
+      (is (= ["base" "path" "foo"]
+             (handler/request-based-timer-id ["base" "path"] item {:uri "/foo/bar/baz/baf?item=123"} {})))))
+
+  (testing "should build path with first 2 resources of uri"
+    (let [item {:timed?                  true
+                :uri-resource-chooser-fn (partial take 2)
+                :use-status-codes?       false}]
+      (is (= ["base" "path" "foo" "bar"]
+             (handler/request-based-timer-id ["base" "path"] item {:uri "/foo/bar/baz/baf?item=123"} {})))))
+
+  (testing "should build path with all but last resource of uri"
+    (let [item {:timed?                  true
+                :uri-resource-chooser-fn pop
+                :use-status-codes?       false}]
+      (is (= ["base" "path" "foo" "bar" "baz"]
+             (handler/request-based-timer-id ["base" "path"] item {:uri "/foo/bar/baz/baf?item=123"} {})))
+      (is (= ["base" "path" "foo" "bar" "baz" "baf" "bif"]
+             (handler/request-based-timer-id ["base" "path"] item {:uri "/foo/bar/baz/baf/bif/bum?item=123"} {}))))))
+
+(deftest request-based-timer-id-with-status
+  (testing "should build path with status code"
+    (let [item {:timed?                  true
+                :uri-resource-chooser-fn (partial take 2)
+                :use-status-codes?       true}]
+      (is (= ["base" "path" "foo" "bar" "200"]
+             (handler/request-based-timer-id ["base" "path"] item {:uri "/foo/bar/baz/baf?item=123"} {:status 200})))
+      (is (= ["base" "path" "foo" "bar" "404"]
+             (handler/request-based-timer-id ["base" "path"] item {:uri "/foo/bar/baz/baf?item=123"} {:status 404})))
+      (is (= ["base" "path" "foo" "bar" "500"]
+             (handler/request-based-timer-id ["base" "path"] item {:uri "/foo/bar/baz/baf?item=123"} {:status 500}))))))
 
 (deftest reporting-base-path
   (testing "should use default reporting base-path"
     (let [reportings (atom [])]
       (with-redefs [handler/time-taken (constantly 100)
-                    handler/report-request-timings! (fn [base-path _ _] (reset! reportings base-path))]
+                    handler/report-request-timings! (fn [base-path _ _ _ _] (reset! reportings base-path))]
         (let [handler (-> (handler/->Handler {:config {:handler {:report-timings? true}}}) (c/start))]
-          (handler/register-handler handler (fn [r] (when (= r :ping) :pong)))
+          (handler/register-timed-handler handler (fn [r] (when (= r :ping) :pong)))
           (is (= :pong ((handler/handler handler) :ping)))
           (is (= ["serving" "requests"] @reportings))))))
 
   (testing "should use configured reporting base-path"
     (let [reportings (atom [])]
       (with-redefs [handler/time-taken (constantly 100)
-                    handler/report-request-timings! (fn [base-path _ _] (reset! reportings base-path))]
+                    handler/report-request-timings! (fn [base-path _ _ _ _] (reset! reportings base-path))]
         (let [handler (-> (handler/->Handler {:config {:handler {:report-timings?     true
                                                                  :reporting-base-path ["foo" "bar" "baz"]}}}) (c/start))]
-          (handler/register-handler handler (fn [r] (when (= r :ping) :pong)))
+          (handler/register-timed-handler handler (fn [r] (when (= r :ping) :pong)))
           (is (= :pong ((handler/handler handler) :ping)))
           (is (= ["foo" "bar" "baz"] @reportings)))))))

--- a/test/de/otto/tesla/stateful/handler_test.clj
+++ b/test/de/otto/tesla/stateful/handler_test.clj
@@ -8,5 +8,14 @@
     (let [handler (-> (handler/new-handler) (c/start))]
       (handler/register-handler handler (fn [r] (when (= r :ping) :pong)))
       (handler/register-handler handler (fn [r] (when (= r :pong) :ping)))
+      (is (= ["tesla-handler-0" "tesla-handler-1"]  (map first @(:the-handlers handler))))
+      (is (= :pong ((handler/handler handler) :ping)))
+      (is (= :ping ((handler/handler handler) :pong)))))
+
+  (testing "should register a handler with a name and return a single handling-function"
+    (let [handler (-> (handler/new-handler) (c/start))]
+      (handler/register-handler handler "ping" (fn [r] (when (= r :ping) :pong)))
+      (handler/register-handler handler "pong" (fn [r] (when (= r :pong) :ping)))
+      (is (= ["ping" "pong"]  (map first @(:the-handlers handler))))
       (is (= :pong ((handler/handler handler) :ping)))
       (is (= :ping ((handler/handler handler) :pong))))))

--- a/test/de/otto/tesla/stateful/handler_test.clj
+++ b/test/de/otto/tesla/stateful/handler_test.clj
@@ -32,24 +32,24 @@
 
 (deftest building-timer-id
   (testing "should build path with first resource of uri"
-    (let [item {:timed?                  true
-                :uri-resource-chooser-fn (partial take 1)}]
+    (let [item {:timed?          true
+                :uri-resource-fn (partial take 1)}]
       (is (= ["base" "path" "foo" "200"]
              (request-based-timer-id ["base" "path"] item {:uri "/foo/bar/baz/baf?item=123"} {:status 200})))
       (is (= ["base" "path" "200"]
              (request-based-timer-id ["base" "path"] item {:uri "/?item=123"} {:status 200})))))
 
   (testing "should build path with first 2 resources of uri"
-    (let [item {:timed?                  true
-                :uri-resource-chooser-fn (partial take 2)}]
+    (let [item {:timed?          true
+                :uri-resource-fn (partial take 2)}]
       (is (= ["base" "path" "foo" "bar" "200"]
              (request-based-timer-id ["base" "path"] item {:uri "/foo/bar/baz/baf?item=123"} {:status 200})))
       (is (= ["base" "path" "200"]
              (request-based-timer-id ["base" "path"] item {:uri "/?item=123"} {:status 200})))))
 
   (testing "should build path with all but last resource of uri"
-    (let [item {:timed?                  true
-                :uri-resource-chooser-fn butlast}]
+    (let [item {:timed?          true
+                :uri-resource-fn butlast}]
       (is (= ["base" "path" "foo" "bar" "baz" "200"]
              (request-based-timer-id ["base" "path"] item {:uri "/foo/bar/baz/baf?item=123"} {:status 200})))
       (is (= ["base" "path" "foo" "bar" "baz" "baf" "bif" "200"]
@@ -59,8 +59,8 @@
 
 (deftest request-based-timer-id-with-status
   (testing "should build path with status code"
-    (let [item {:timed?                  true
-                :uri-resource-chooser-fn (partial take 2)}]
+    (let [item {:timed?          true
+                :uri-resource-fn (partial take 2)}]
       (is (= ["base" "path" "foo" "bar" "200"]
              (request-based-timer-id ["base" "path"] item {:uri "/foo/bar/baz/baf?item=123"} {:status 200})))
       (is (= ["base" "path" "foo" "bar" "404"]
@@ -105,10 +105,10 @@
 
       (testing "should store registered timer"
         (handler/register-timed-handler handler custom-handler-fn)
-        (is (= [{:handler                 custom-handler-fn
-                 :handler-name            "tesla-handler-0"
-                 :timed?                  true
-                 :uri-resource-chooser-fn identity}]
+        (is (= [{:handler         custom-handler-fn
+                 :handler-name    "tesla-handler-0"
+                 :timed?          true
+                 :uri-resource-fn identity}]
                @(:registered-handlers handler))))
 
       (testing "should respond with valid response and store + update timer"

--- a/test/de/otto/tesla/stateful/handler_test.clj
+++ b/test/de/otto/tesla/stateful/handler_test.clj
@@ -31,38 +31,34 @@
 (deftest building-timer-id
   (testing "should build path with first resource of uri"
     (let [item {:timed?                  true
-                :uri-resource-chooser-fn (partial take 1)
-                :use-status-codes?       false}]
-      (is (= ["base" "path" "foo"]
-             (handler/request-based-timer-id ["base" "path"] item {:uri "/foo/bar/baz/baf?item=123"} {})))
-      (is (= ["base" "path"]
-             (handler/request-based-timer-id ["base" "path"] item {:uri "/?item=123"} {})))))
+                :uri-resource-chooser-fn (partial take 1)}]
+      (is (= ["base" "path" "foo" "200"]
+             (handler/request-based-timer-id ["base" "path"] item {:uri "/foo/bar/baz/baf?item=123"} {:status 200})))
+      (is (= ["base" "path" "200"]
+             (handler/request-based-timer-id ["base" "path"] item {:uri "/?item=123"} {:status 200})))))
 
   (testing "should build path with first 2 resources of uri"
     (let [item {:timed?                  true
-                :uri-resource-chooser-fn (partial take 2)
-                :use-status-codes?       false}]
-      (is (= ["base" "path" "foo" "bar"]
-             (handler/request-based-timer-id ["base" "path"] item {:uri "/foo/bar/baz/baf?item=123"} {})))
-      (is (= ["base" "path"]
-             (handler/request-based-timer-id ["base" "path"] item {:uri "/?item=123"} {})))))
+                :uri-resource-chooser-fn (partial take 2)}]
+      (is (= ["base" "path" "foo" "bar" "200"]
+             (handler/request-based-timer-id ["base" "path"] item {:uri "/foo/bar/baz/baf?item=123"} {:status 200})))
+      (is (= ["base" "path" "200"]
+             (handler/request-based-timer-id ["base" "path"] item {:uri "/?item=123"} {:status 200})))))
 
   (testing "should build path with all but last resource of uri"
     (let [item {:timed?                  true
-                :uri-resource-chooser-fn butlast
-                :use-status-codes?       false}]
-      (is (= ["base" "path" "foo" "bar" "baz"]
-             (handler/request-based-timer-id ["base" "path"] item {:uri "/foo/bar/baz/baf?item=123"} {})))
-      (is (= ["base" "path" "foo" "bar" "baz" "baf" "bif"]
-             (handler/request-based-timer-id ["base" "path"] item {:uri "/foo/bar/baz/baf/bif/bum?item=123"} {})))
-      (is (= ["base" "path"]
-             (handler/request-based-timer-id ["base" "path"] item {:uri "/?item=123"} {}))))))
+                :uri-resource-chooser-fn butlast}]
+      (is (= ["base" "path" "foo" "bar" "baz" "200"]
+             (handler/request-based-timer-id ["base" "path"] item {:uri "/foo/bar/baz/baf?item=123"} {:status 200})))
+      (is (= ["base" "path" "foo" "bar" "baz" "baf" "bif" "200"]
+             (handler/request-based-timer-id ["base" "path"] item {:uri "/foo/bar/baz/baf/bif/bum?item=123"} {:status 200})))
+      (is (= ["base" "path" "200"]
+             (handler/request-based-timer-id ["base" "path"] item {:uri "/?item=123"} {:status 200}))))))
 
 (deftest request-based-timer-id-with-status
   (testing "should build path with status code"
     (let [item {:timed?                  true
-                :uri-resource-chooser-fn (partial take 2)
-                :use-status-codes?       true}]
+                :uri-resource-chooser-fn (partial take 2)}]
       (is (= ["base" "path" "foo" "bar" "200"]
              (handler/request-based-timer-id ["base" "path"] item {:uri "/foo/bar/baz/baf?item=123"} {:status 200})))
       (is (= ["base" "path" "foo" "bar" "404"]
@@ -109,8 +105,7 @@
         (is (= [{:handler                 custom-handler-fn
                  :handler-name            "tesla-handler-0"
                  :timed?                  true
-                 :uri-resource-chooser-fn identity
-                 :use-status-codes?       true}]
+                 :uri-resource-chooser-fn identity}]
                @(:registered-handlers handler))))
 
       (testing "should respond with valid response and store + update timer"

--- a/test/de/otto/tesla/stateful/handler_test.clj
+++ b/test/de/otto/tesla/stateful/handler_test.clj
@@ -8,7 +8,7 @@
     (let [handler (-> (handler/new-handler) (c/start))]
       (handler/register-handler handler (fn [r] (when (= r :ping) :pong)))
       (handler/register-handler handler (fn [r] (when (= r :pong) :ping)))
-      (is (= ["tesla-handler-0" "tesla-handler-1"]  (map first @(:the-handlers handler))))
+      (is (= ["tesla-handler-0" "tesla-handler-1"]  (map :handler-name @(:the-handlers handler))))
       (is (= :pong ((handler/handler handler) :ping)))
       (is (= :ping ((handler/handler handler) :pong)))))
 
@@ -16,6 +16,6 @@
     (let [handler (-> (handler/new-handler) (c/start))]
       (handler/register-handler handler "ping" (fn [r] (when (= r :ping) :pong)))
       (handler/register-handler handler "pong" (fn [r] (when (= r :pong) :ping)))
-      (is (= ["ping" "pong"]  (map first @(:the-handlers handler))))
+      (is (= ["ping" "pong"]  (map :handler-name @(:the-handlers handler))))
       (is (= :pong ((handler/handler handler) :ping)))
       (is (= :ping ((handler/handler handler) :pong))))))

--- a/test/de/otto/tesla/stateful/handler_test.clj
+++ b/test/de/otto/tesla/stateful/handler_test.clj
@@ -4,6 +4,13 @@
             [com.stuartsierra.component :as c])
   (:import (com.codahale.metrics Timer)))
 
+(def ping->pong-route (fn [{:keys [uri]}] (when (= uri "/ping") {:body   :pong
+                                                                 :status 200})))
+
+(def pong->ping-route (fn [{:keys [uri]}] (when (= uri "/pong") {:body   :ping
+                                                                 :status 200})))
+
+
 (deftest registering-handlers
   (testing "should register a handler and return a single handling-function"
     (let [handler (-> (handler/new-handler) (c/start))]
@@ -17,56 +24,53 @@
   (testing "should use timed handler"
     (let [reportings (atom [])]
       (with-redefs [handler/time-taken (constantly 100)
-                    handler/report-request-timings! (fn [_ item _ _ time-taken] (swap! reportings conj [(:handler-name item) time-taken]))]
+                    handler/report-request-timings! (fn [timer-id _ time-taken] (swap! reportings conj [timer-id time-taken]))]
         (let [handler (-> (handler/new-handler) (c/start))]
-          (handler/register-timed-handler handler (fn [r] (when (= r :ping) :pong)))
-          (handler/register-timed-handler handler (fn [r] (when (= r :pong) :ping)))
+          (handler/register-timed-handler handler ping->pong-route)
+          (handler/register-timed-handler handler pong->ping-route)
           (is (= ["tesla-handler-0" "tesla-handler-1"]
                  (map :handler-name @(:registered-handlers handler))))
-          (is (= :pong ((handler/handler handler) :ping)))
-          (is (= [["tesla-handler-0" 100]] @reportings))
-          (is (= :ping ((handler/handler handler) :pong)))
-          (is (= [["tesla-handler-0" 100] ["tesla-handler-1" 100]] @reportings)))))))
+          (is (= {:body :pong :status 200} ((handler/handler handler) {:uri "/ping"})))
+          (is (= [[["serving" "requests" "ping" "200"] 100]] @reportings))
+          (is (= {:body :ping :status 200} ((handler/handler handler) {:uri "/pong"})))
+          (is (= [[["serving" "requests" "ping" "200"] 100]
+                  [["serving" "requests" "pong" "200"] 100]] @reportings)))))))
 
 (def request-based-timer-id #'handler/request-based-timer-id)
 
 (deftest building-timer-id
   (testing "should build path with first resource of uri"
-    (let [item {:timed?          true
-                :uri-resource-fn (partial take 1)}]
+    (let [uri-resource-fn (partial take 1)]
       (is (= ["base" "path" "foo" "200"]
-             (request-based-timer-id ["base" "path"] item {:uri "/foo/bar/baz/baf?item=123"} {:status 200})))
+             (request-based-timer-id ["base" "path"] uri-resource-fn {:uri "/foo/bar/baz/baf?item=123"} {:status 200})))
       (is (= ["base" "path" "200"]
-             (request-based-timer-id ["base" "path"] item {:uri "/?item=123"} {:status 200})))))
+             (request-based-timer-id ["base" "path"] uri-resource-fn {:uri "/?item=123"} {:status 200})))))
 
   (testing "should build path with first 2 resources of uri"
-    (let [item {:timed?          true
-                :uri-resource-fn (partial take 2)}]
+    (let [uri-resource-fn (partial take 2)]
       (is (= ["base" "path" "foo" "bar" "200"]
-             (request-based-timer-id ["base" "path"] item {:uri "/foo/bar/baz/baf?item=123"} {:status 200})))
+             (request-based-timer-id ["base" "path"] uri-resource-fn {:uri "/foo/bar/baz/baf?item=123"} {:status 200})))
       (is (= ["base" "path" "200"]
-             (request-based-timer-id ["base" "path"] item {:uri "/?item=123"} {:status 200})))))
+             (request-based-timer-id ["base" "path"] uri-resource-fn {:uri "/?item=123"} {:status 200})))))
 
   (testing "should build path with all but last resource of uri"
-    (let [item {:timed?          true
-                :uri-resource-fn butlast}]
+    (let [uri-resource-fn butlast]
       (is (= ["base" "path" "foo" "bar" "baz" "200"]
-             (request-based-timer-id ["base" "path"] item {:uri "/foo/bar/baz/baf?item=123"} {:status 200})))
+             (request-based-timer-id ["base" "path"] uri-resource-fn {:uri "/foo/bar/baz/baf?item=123"} {:status 200})))
       (is (= ["base" "path" "foo" "bar" "baz" "baf" "bif" "200"]
-             (request-based-timer-id ["base" "path"] item {:uri "/foo/bar/baz/baf/bif/bum?item=123"} {:status 200})))
+             (request-based-timer-id ["base" "path"] uri-resource-fn {:uri "/foo/bar/baz/baf/bif/bum?item=123"} {:status 200})))
       (is (= ["base" "path" "200"]
-             (request-based-timer-id ["base" "path"] item {:uri "/?item=123"} {:status 200}))))))
+             (request-based-timer-id ["base" "path"] uri-resource-fn {:uri "/?item=123"} {:status 200}))))))
 
 (deftest request-based-timer-id-with-status
   (testing "should build path with status code"
-    (let [item {:timed?          true
-                :uri-resource-fn (partial take 2)}]
+    (let [uri-resource-fn (partial take 2)]
       (is (= ["base" "path" "foo" "bar" "200"]
-             (request-based-timer-id ["base" "path"] item {:uri "/foo/bar/baz/baf?item=123"} {:status 200})))
+             (request-based-timer-id ["base" "path"] uri-resource-fn {:uri "/foo/bar/baz/baf?item=123"} {:status 200})))
       (is (= ["base" "path" "foo" "bar" "404"]
-             (request-based-timer-id ["base" "path"] item {:uri "/foo/bar/baz/baf?item=123"} {:status 404})))
+             (request-based-timer-id ["base" "path"] uri-resource-fn {:uri "/foo/bar/baz/baf?item=123"} {:status 404})))
       (is (= ["base" "path" "foo" "bar" "500"]
-             (request-based-timer-id ["base" "path"] item {:uri "/foo/bar/baz/baf?item=123"} {:status 500}))))))
+             (request-based-timer-id ["base" "path"] uri-resource-fn {:uri "/foo/bar/baz/baf?item=123"} {:status 500}))))))
 
 (def trimmed-uri-path #'handler/trimmed-uri-path)
 (deftest trimmed-uri-path-test
@@ -78,43 +82,39 @@
   (testing "should use default reporting base-path"
     (let [reportings (atom [])]
       (with-redefs [handler/time-taken (constantly 100)
-                    handler/report-request-timings! (fn [self _ _ _ _] (reset! reportings (:reporting-base-path self)))]
+                    handler/report-request-timings! (fn [_ self _] (reset! reportings (:reporting-base-path self)))]
         (let [handler (-> (handler/->Handler {}) (c/start))]
-          (handler/register-timed-handler handler (fn [r] (when (= r :ping) :pong)))
-          (is (= :pong ((handler/handler handler) :ping)))
+          (handler/register-timed-handler handler ping->pong-route)
+          (is (= {:body :pong :status 200} ((handler/handler handler) {:uri "/ping"})))
           (is (= ["serving" "requests"] @reportings))))))
 
   (testing "should use configured reporting base-path"
     (let [reportings (atom [])]
       (with-redefs [handler/time-taken (constantly 100)
-                    handler/report-request-timings! (fn [self _ _ _ _] (reset! reportings (:reporting-base-path self)))]
+                    handler/report-request-timings! (fn [_ self _] (reset! reportings (:reporting-base-path self)))]
         (let [handler (-> (handler/->Handler {:config {:handler {:reporting-base-path ["foo" "bar" "baz"]}}}) (c/start))]
-          (handler/register-timed-handler handler (fn [r] (when (= r :ping) :pong)))
-          (is (= :pong ((handler/handler handler) :ping)))
+          (handler/register-timed-handler handler ping->pong-route)
+          (is (= {:body :pong :status 200} ((handler/handler handler) {:uri "/ping"})))
           (is (= ["foo" "bar" "baz"] @reportings)))))))
 
 
 (deftest storing-timers
   (let [handler (-> (handler/->Handler {}) (c/start))
         timer-updates (atom [])
-        mock-timer (proxy [Timer] [] (update [v _] (swap! timer-updates conj v)))
-        custom-handler-fn (fn [r] (when (= (:uri r) "/ping") {:status 200 :body :pong}))]
+        mock-timer (proxy [Timer] [] (update [v _] (swap! timer-updates conj v)))]
     (with-redefs [handler/register-timer (constantly nil)
                   handler/time-taken (constantly 100)
                   handler/sliding-window-timer (constantly mock-timer)]
 
-      (testing "should store registered timer"
-        (handler/register-timed-handler handler custom-handler-fn)
-        (is (= [{:handler         custom-handler-fn
-                 :handler-name    "tesla-handler-0"
-                 :timed?          true
-                 :uri-resource-fn identity}]
-               @(:registered-handlers handler))))
+      (testing "should store registered handler"
+        (handler/register-timed-handler handler ping->pong-route)
+        (is (= {:handler      ping->pong-route
+                :handler-name "tesla-handler-0"}
+               (dissoc (first @(:registered-handlers handler)) :timer-path-fn)))
+        (is (fn? (:timer-path-fn (first @(:registered-handlers handler))))))
 
       (testing "should respond with valid response and store + update timer"
-        (is (= {:status 200
-                :body   :pong}
-               ((handler/handler handler) {:uri "/ping"})))
+        (is (= {:status 200 :body :pong} ((handler/handler handler) {:uri "/ping"})))
         (is (= {"serving.requests.ping.200" mock-timer} @(:timers handler)))
         (is (= [100] @timer-updates)))
 
@@ -124,3 +124,79 @@
 
         (is (= {"serving.requests.ping.200" mock-timer} @(:timers handler)))
         (is (= [100 100 100] @timer-updates))))))
+
+(def timer-for-id #'handler/timer-for-id)
+(deftest stringifiy-timer-ids
+  (testing "should stringify all timerid-arrays"
+    (let [timers (atom {"1.2.3.4.5" :mock-timer})]
+      (is (= :mock-timer (timer-for-id {:timers timers} ["1" "2" "3" "4" "5"]))))))
+
+(deftest storing-timers-for-custom-timer-path-fn
+  (let [handler (-> (handler/->Handler {}) (c/start))
+        timer-updates (atom [])
+        mock-timer (proxy [Timer] [] (update [v _] (swap! timer-updates conj v)))
+        custom-timer-path-fn (fn [request response]
+                               ["custom" (:status response) (get-in request [:headers :foo]) "handler"])]
+    (with-redefs [handler/register-timer (constantly nil)
+                  handler/time-taken (constantly 100)
+                  handler/sliding-window-timer (constantly mock-timer)]
+
+      (testing "should store registered timer"
+        (handler/register-timed-handler handler ping->pong-route
+                                        :timer-path-fn custom-timer-path-fn
+                                        )
+        (is (= [{:handler       ping->pong-route
+                 :handler-name  "tesla-handler-0"
+                 :timer-path-fn custom-timer-path-fn}]
+               @(:registered-handlers handler))))
+
+      (testing "should respond with valid response and store + update timer"
+        (is (= {:status 200
+                :body   :pong}
+               ((handler/handler handler) {:uri "/ping" :headers {:foo "foo-header"}})))
+        (is (= {"custom.200.foo-header.handler" mock-timer} @(:timers handler)))
+        (is (= [100] @timer-updates)))
+
+      (testing "should reuse timer for further updates"
+        ((handler/handler handler) {:uri "/ping" :headers {:foo "foo-header"}})
+        ((handler/handler handler) {:uri "/ping" :headers {:foo "bar-header"}})
+
+        (is (= {"custom.200.foo-header.handler" mock-timer
+                "custom.200.bar-header.handler" mock-timer} @(:timers handler)))
+        (is (= [100 100 100] @timer-updates))))))
+
+(def single-handler-fn #'handler/single-handler-fn)
+(deftest the-single-handler-fn
+  (let [reportings (atom [])]
+    (with-redefs [handler/time-taken (constantly 100)
+                  handler/report-request-timings! (fn [timer-id _ time-taken] (swap! reportings conj [timer-id time-taken]))]
+      (testing "should execute the single handler-fn"
+        (reset! reportings [])
+        (let [registered-handlers (atom [{:handler (fn [r] {:status 200 :body :dummy-response})}])]
+          (is (= {:status 200 :body :dummy-response}
+                 ((single-handler-fn {:registered-handlers registered-handlers}) {:uri "/"})))
+          (is (= []  @reportings))))
+
+      (testing "should execute the single handler-fn"
+        (reset! reportings [])
+        (let [registered-handlers (atom [{:timer-path-fn (constantly ["testpath"])
+                                          :handler       (fn [r] {:status 200 :body :dummy-response})}])]
+          (is (= {:status 200 :body :dummy-response}
+                 ((single-handler-fn {:registered-handlers registered-handlers}) {:uri "/"})))
+          (is (= [[["testpath"] 100]] @reportings))))
+
+      (testing "should execute the single handler-fn and stringify elements in vector"
+        (reset! reportings [])
+        (let [registered-handlers (atom [{:timer-path-fn (constantly [1 2 3])
+                                          :handler       (fn [r] {:status 200 :body :dummy-response})}])]
+          (is (= {:status 200 :body :dummy-response}
+                 ((single-handler-fn {:registered-handlers registered-handlers}) {:uri "/"})))
+          (is (= [[["1" "2" "3"] 100]] @reportings))))
+
+      (testing "should execute the single handler-fn and report nothing if path-fn throws an exception"
+        (reset! reportings [])
+        (let [registered-handlers (atom [{:timer-path-fn (fn [_ _] (throw (RuntimeException. "TextException")))
+                                          :handler       (fn [r] {:status 200 :body :dummy-response})}])]
+          (is (= {:status 200 :body :dummy-response}
+                 ((single-handler-fn {:registered-handlers registered-handlers}) {:uri "/"})))
+          (is (= [] @reportings)))))))

--- a/test/de/otto/tesla/stateful/handler_test.clj
+++ b/test/de/otto/tesla/stateful/handler_test.clj
@@ -33,23 +33,29 @@
                 :uri-resource-chooser-fn (partial take 1)
                 :use-status-codes?       false}]
       (is (= ["base" "path" "foo"]
-             (handler/request-based-timer-id ["base" "path"] item {:uri "/foo/bar/baz/baf?item=123"} {})))))
+             (handler/request-based-timer-id ["base" "path"] item {:uri "/foo/bar/baz/baf?item=123"} {})))
+      (is (= ["base" "path"]
+             (handler/request-based-timer-id ["base" "path"] item {:uri "/?item=123"} {})))))
 
   (testing "should build path with first 2 resources of uri"
     (let [item {:timed?                  true
                 :uri-resource-chooser-fn (partial take 2)
                 :use-status-codes?       false}]
       (is (= ["base" "path" "foo" "bar"]
-             (handler/request-based-timer-id ["base" "path"] item {:uri "/foo/bar/baz/baf?item=123"} {})))))
+             (handler/request-based-timer-id ["base" "path"] item {:uri "/foo/bar/baz/baf?item=123"} {})))
+      (is (= ["base" "path"]
+             (handler/request-based-timer-id ["base" "path"] item {:uri "/?item=123"} {})))))
 
   (testing "should build path with all but last resource of uri"
     (let [item {:timed?                  true
-                :uri-resource-chooser-fn pop
+                :uri-resource-chooser-fn #(if (empty? %) % (pop %))
                 :use-status-codes?       false}]
       (is (= ["base" "path" "foo" "bar" "baz"]
              (handler/request-based-timer-id ["base" "path"] item {:uri "/foo/bar/baz/baf?item=123"} {})))
       (is (= ["base" "path" "foo" "bar" "baz" "baf" "bif"]
-             (handler/request-based-timer-id ["base" "path"] item {:uri "/foo/bar/baz/baf/bif/bum?item=123"} {}))))))
+             (handler/request-based-timer-id ["base" "path"] item {:uri "/foo/bar/baz/baf/bif/bum?item=123"} {})))
+      (is (= ["base" "path"]
+             (handler/request-based-timer-id ["base" "path"] item {:uri "/?item=123"} {}))))))
 
 (deftest request-based-timer-id-with-status
   (testing "should build path with status code"
@@ -62,6 +68,11 @@
              (handler/request-based-timer-id ["base" "path"] item {:uri "/foo/bar/baz/baf?item=123"} {:status 404})))
       (is (= ["base" "path" "foo" "bar" "500"]
              (handler/request-based-timer-id ["base" "path"] item {:uri "/foo/bar/baz/baf?item=123"} {:status 500}))))))
+
+(deftest trimmed-uri-path
+  (testing "should trim uri path"
+    (is (= "foo/bar/baz" (handler/trimmed-uri-path "/foo/bar/baz?a=b&c=d")))
+    (is (= nil (handler/trimmed-uri-path "/?a=b&c=d")))))
 
 (deftest reporting-base-path
   (testing "should use default reporting base-path"

--- a/test/de/otto/tesla/stateful/handler_test.clj
+++ b/test/de/otto/tesla/stateful/handler_test.clj
@@ -1,0 +1,12 @@
+(ns de.otto.tesla.stateful.handler-test
+  (:require [clojure.test :refer :all]
+            [de.otto.tesla.stateful.handler :as handler]
+            [com.stuartsierra.component :as c]))
+
+(deftest registering-handlers
+  (testing "should register a handler and return a single handling-function"
+    (let [handler (-> (handler/new-handler) (c/start))]
+      (handler/register-handler handler (fn [r] (when (= r :ping) :pong)))
+      (handler/register-handler handler (fn [r] (when (= r :pong) :ping)))
+      (is (= :pong ((handler/handler handler) :ping)))
+      (is (= :ping ((handler/handler handler) :pong))))))

--- a/test/de/otto/tesla/stateful/handler_test.clj
+++ b/test/de/otto/tesla/stateful/handler_test.clj
@@ -8,7 +8,7 @@
     (let [handler (-> (handler/new-handler) (c/start))]
       (handler/register-handler handler (fn [r] (when (= r :ping) :pong)))
       (handler/register-handler handler (fn [r] (when (= r :pong) :ping)))
-      (is (= ["tesla-handler-0" "tesla-handler-1"]  (map :handler-name @(:the-handlers handler))))
+      (is (= ["tesla-handler-0" "tesla-handler-1"] (map :handler-name @(:the-handlers handler))))
       (is (= :pong ((handler/handler handler) :ping)))
       (is (= :ping ((handler/handler handler) :pong)))))
 
@@ -16,7 +16,7 @@
     (let [handler (-> (handler/new-handler) (c/start))]
       (handler/register-handler handler "ping" (fn [r] (when (= r :ping) :pong)))
       (handler/register-handler handler "pong" (fn [r] (when (= r :pong) :ping)))
-      (is (= ["ping" "pong"]  (map :handler-name @(:the-handlers handler))))
+      (is (= ["ping" "pong"] (map :handler-name @(:the-handlers handler))))
       (is (= :pong ((handler/handler handler) :ping)))
       (is (= :ping ((handler/handler handler) :pong))))))
 
@@ -24,7 +24,7 @@
   (testing "should use timed handler"
     (let [reportings (atom [])]
       (with-redefs [handler/time-taken (constantly 100)
-                    handler/report-request-timings! (fn [handler-name time-taken] (swap! reportings conj [handler-name time-taken]))]
+                    handler/report-request-timings! (fn [_ handler-name time-taken] (swap! reportings conj [handler-name time-taken]))]
         (let [handler (-> (handler/->Handler {:config {:handler {:report-timings? true}}}) (c/start))]
           (handler/register-handler handler (fn [r] (when (= r :ping) :pong)))
           (handler/register-handler handler (fn [r] (when (= r :pong) :ping)))
@@ -33,3 +33,31 @@
           (is (= [["tesla-handler-0" 100]] @reportings))
           (is (= :ping ((handler/handler handler) :pong)))
           (is (= [["tesla-handler-0" 100] ["tesla-handler-1" 100]] @reportings)))))))
+
+(def timer-id handler/timer-id)
+(deftest building-timer-id
+  (testing "should build timer-id"
+    (is (= ["a" "b" "c" "d"]
+           (timer-id ["a" "b" "c"] "d")))
+    (is (= ["d"]
+           (timer-id [] "d")))))
+
+(deftest reporting-base-path
+  (testing "should use default reporting base-path"
+    (let [reportings (atom [])]
+      (with-redefs [handler/time-taken (constantly 100)
+                    handler/report-request-timings! (fn [base-path _ _] (reset! reportings base-path))]
+        (let [handler (-> (handler/->Handler {:config {:handler {:report-timings? true}}}) (c/start))]
+          (handler/register-handler handler (fn [r] (when (= r :ping) :pong)))
+          (is (= :pong ((handler/handler handler) :ping)))
+          (is (= ["serving" "requests"] @reportings))))))
+
+  (testing "should use configured reporting base-path"
+    (let [reportings (atom [])]
+      (with-redefs [handler/time-taken (constantly 100)
+                    handler/report-request-timings! (fn [base-path _ _] (reset! reportings base-path))]
+        (let [handler (-> (handler/->Handler {:config {:handler {:report-timings?     true
+                                                                 :reporting-base-path ["foo" "bar" "baz"]}}}) (c/start))]
+          (handler/register-handler handler (fn [r] (when (= r :ping) :pong)))
+          (is (= :pong ((handler/handler handler) :ping)))
+          (is (= ["foo" "bar" "baz"] @reportings)))))))

--- a/test/de/otto/tesla/system_test.clj
+++ b/test/de/otto/tesla/system_test.clj
@@ -82,7 +82,7 @@
   (testing "should time and report request for handler"
     (let [reportings (atom [])]
       (with-redefs [handler/time-taken (constantly 100)
-                    handler/report-request-timings! (fn [handler-name time-taken] (swap! reportings conj [handler-name time-taken]))]
+                    handler/report-request-timings! (fn [_ handler-name time-taken] (swap! reportings conj [handler-name time-taken]))]
         (u/with-started [started (-> (system/base-system {:handler {:report-timings? true}})
                                      (assoc
                                        :route0 (test-route 0)


### PR DESCRIPTION
This pull-request would enable the handler to time requests and report the results to graphite.
By default the API works as before and does not time anything:

``` clj
(handler/register-handler handler-component your-handler-fn)
```

If you want to time a handler, you have to specify this on registration time, by using the new api-method `register-timed-handler`.

``` clj
(handler/register-timed-handler handler-component your-handler-fn)
```

Every request which is handled by `your-handler-fn` is then timed and the results are reported to a Timer with a SlidingTimeWindow (window size is configurable). The Timer-Id is based on three things:
- a base path which can be specified in the config (`:reporting-base-path`) and defaults to `["serving" "requests"]`
- the uri-resources from the request (e.g. `"/foo/bar?a=b" -> ["foo" "bar"]`)
- (optional) the status code from your response

**Example:**
base-path = `["base" "path"]`
request = `{:uri "/foo/bar?a=b&c=d"}`
response = `{:status 200}`
The Timer-Id then is `["base" "path" "foo" "bar"  "200"]`

**Configuration:**
By Default if you use 

``` clj
(handler/register-timed-handler handler-component your-handler-fn)
```

all resources from the uris are used and status codes are appended.

If you want more specific behaviour you can use this: 

``` clj
(handler/register-timed-handler handler-component your-handler-fn (partial take 2) false)
```

which would take the first 2 resources from the uri and append NO status-codes.

Let me know what you think.
